### PR TITLE
refactor: extract type-specific loading state wrappers

### DIFF
--- a/resources/views/app/block.blade.php
+++ b/resources/views/app/block.blade.php
@@ -49,17 +49,11 @@
                             <h2 class="text-3xl sm:text-4xl">@lang('pages.block.transactions')</h2>
                         </div>
 
-                        <div class="w-full" wire:loading>
-                            <x-transactions.table-desktop-skeleton />
-
-                            <x-transactions.table-mobile-skeleton />
-                        </div>
-
-                        <div class="w-full" wire:loading.remove>
+                        <x-skeletons.transactions>
                             <x-transactions.table-desktop :transactions="$transactions" />
 
                             <x-transactions.table-mobile :transactions="$transactions" />
-                        </div>
+                        </x-skeletons.transactions>
                     </div>
                 </div>
             </div>

--- a/resources/views/components/loading/hidden.blade.php
+++ b/resources/views/components/loading/hidden.blade.php
@@ -1,0 +1,3 @@
+<div class="w-full" wire:loading.remove>
+    {{ $slot }}
+</div>

--- a/resources/views/components/loading/visible.blade.php
+++ b/resources/views/components/loading/visible.blade.php
@@ -1,0 +1,3 @@
+<div class="w-full" wire:loading>
+    {{ $slot }}
+</div>

--- a/resources/views/components/skeletons/blocks.blade.php
+++ b/resources/views/components/skeletons/blocks.blade.php
@@ -1,0 +1,9 @@
+<div class="w-full" wire:loading>
+    <x-blocks.table-desktop-skeleton />
+
+    <x-blocks.table-mobile-skeleton />
+</div>
+
+<div class="w-full" wire:loading.remove>
+    {{ $slot }}
+</div>

--- a/resources/views/components/skeletons/blocks.blade.php
+++ b/resources/views/components/skeletons/blocks.blade.php
@@ -1,9 +1,9 @@
-<div class="w-full" wire:loading>
+<x-loading.visible>
     <x-blocks.table-desktop-skeleton />
 
     <x-blocks.table-mobile-skeleton />
-</div>
+</x-loading.visible>
 
-<div class="w-full" wire:loading.remove>
+<x-loading.hidden>
     {{ $slot }}
-</div>
+</x-loading.hidden>

--- a/resources/views/components/skeletons/transactions-extended.blade.php
+++ b/resources/views/components/skeletons/transactions-extended.blade.php
@@ -1,9 +1,9 @@
-<div class="w-full" wire:loading>
+<x-loading.visible>
     <x-transactions.table-desktop-skeleton use-confirmations use-direction />
 
     <x-transactions.table-mobile-skeleton use-confirmations use-direction />
-</div>
+</x-loading.visible>
 
-<div class="w-full" wire:loading.remove>
+<x-loading.hidden>
     {{ $slot }}
-</div>
+</x-loading.hidden>

--- a/resources/views/components/skeletons/transactions-extended.blade.php
+++ b/resources/views/components/skeletons/transactions-extended.blade.php
@@ -1,0 +1,9 @@
+<div class="w-full" wire:loading>
+    <x-transactions.table-desktop-skeleton use-confirmations use-direction />
+
+    <x-transactions.table-mobile-skeleton use-confirmations use-direction />
+</div>
+
+<div class="w-full" wire:loading.remove>
+    {{ $slot }}
+</div>

--- a/resources/views/components/skeletons/transactions.blade.php
+++ b/resources/views/components/skeletons/transactions.blade.php
@@ -1,9 +1,9 @@
-<div class="w-full" wire:loading>
+<x-loading.visible>
     <x-transactions.table-desktop-skeleton />
 
     <x-transactions.table-mobile-skeleton />
-</div>
+</x-loading.visible>
 
-<div class="w-full" wire:loading.remove>
+<x-loading.hidden>
     {{ $slot }}
-</div>
+</x-loading.hidden>

--- a/resources/views/components/skeletons/transactions.blade.php
+++ b/resources/views/components/skeletons/transactions.blade.php
@@ -1,0 +1,9 @@
+<div class="w-full" wire:loading>
+    <x-transactions.table-desktop-skeleton />
+
+    <x-transactions.table-mobile-skeleton />
+</div>
+
+<div class="w-full" wire:loading.remove>
+    {{ $slot }}
+</div>

--- a/resources/views/components/skeletons/wallets.blade.php
+++ b/resources/views/components/skeletons/wallets.blade.php
@@ -1,9 +1,9 @@
-<div class="w-full" wire:loading>
+<x-loading.visible>
     <x-wallets.table-desktop-skeleton />
 
     <x-wallets.table-mobile-skeleton />
-</div>
+</x-loading.visible>
 
-<div class="w-full" wire:loading.remove>
+<x-loading.hidden>
     {{ $slot }}
-</div>
+</x-loading.hidden>

--- a/resources/views/components/skeletons/wallets.blade.php
+++ b/resources/views/components/skeletons/wallets.blade.php
@@ -1,0 +1,9 @@
+<div class="w-full" wire:loading>
+    <x-wallets.table-desktop-skeleton />
+
+    <x-wallets.table-mobile-skeleton />
+</div>
+
+<div class="w-full" wire:loading.remove>
+    {{ $slot }}
+</div>

--- a/resources/views/components/tables/blocks.blade.php
+++ b/resources/views/components/tables/blocks.blade.php
@@ -1,11 +1,5 @@
 <div id="block-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-blocks.table-desktop-skeleton />
-
-        <x-blocks.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.blocks>
         <x-blocks.table-desktop :blocks="$blocks" />
 
         <x-blocks.table-mobile :blocks="$blocks" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#block-list')));
         </script>
-    </div>
+    </x-skeletons.blocks>
 </div>

--- a/resources/views/components/tables/payments.blade.php
+++ b/resources/views/components/tables/payments.blade.php
@@ -1,13 +1,13 @@
 <div id="payments-list" class="w-full">
-    <div class="w-full" wire:loading>
+    <x-loading.visible>
         <x-payments.table-desktop-skeleton />
 
         <x-payments.table-mobile-skeleton />
-    </div>
+    </x-loading.visible>
 
-    <div class="w-full" wire:loading.remove>
+    <x-loading.hidden>
         <x-payments.table-desktop :payments="$payments" />
 
         <x-payments.table-mobile :payments="$payments" />
-    </div>
+    </x-loading.hidden>
 </div>

--- a/resources/views/components/tables/transactions.blade.php
+++ b/resources/views/components/tables/transactions.blade.php
@@ -1,11 +1,5 @@
 <div id="transaction-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-transactions.table-desktop-skeleton />
-
-        <x-transactions.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.transactions>
         <x-transactions.table-desktop :transactions="$transactions" />
 
         <x-transactions.table-mobile :transactions="$transactions" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#block-list')));
         </script>
-    </div>
+    </x-skeletons.transactions>
 </div>

--- a/resources/views/components/tables/wallets.blade.php
+++ b/resources/views/components/tables/wallets.blade.php
@@ -1,11 +1,5 @@
 <div id="wallet-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-wallets.table-desktop-skeleton />
-
-        <x-wallets.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.wallets>
         <x-wallets.table-desktop :wallets="$wallets" />
 
         <x-wallets.table-mobile :wallets="$wallets" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#block-list')));
         </script>
-    </div>
+    </x-skeletons.wallets>
 </div>

--- a/resources/views/livewire/block-table.blade.php
+++ b/resources/views/livewire/block-table.blade.php
@@ -1,11 +1,5 @@
 <div id="block-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-blocks.table-desktop-skeleton />
-
-        <x-blocks.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.blocks>
         <x-blocks.table-desktop :blocks="$blocks" />
 
         <x-blocks.table-mobile :blocks="$blocks" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#block-list')));
         </script>
-    </div>
+    </x-skeletons.blocks>
 </div>

--- a/resources/views/livewire/monitor-delegate-table.blade.php
+++ b/resources/views/livewire/monitor-delegate-table.blade.php
@@ -1,38 +1,38 @@
 <div id="delegate-list" class="w-full">
     @if($this->state['status'] === 'resigned')
-        <div class="w-full" wire:loading>
+        <x-loading.visible>
             <x-delegates.table-desktop-resigned-skeleton />
             <x-delegates.table-mobile-resigned-skeleton />
-        </div>
+        </x-loading.visible>
 
-        <div class="w-full" wire:loading.remove>
+        <x-loading.hidden>
             <x-delegates.table-desktop-resigned :delegates="$delegates" />
             <x-delegates.table-mobile-resigned :delegates="$delegates" />
-        </div>
+        </x-loading.hidden>
     @endif
 
     @if($this->state['status'] === 'standby')
-        <div class="w-full" wire:loading>
+        <x-loading.visible>
             <x-delegates.table-desktop-standby-skeleton />
             <x-delegates.table-mobile-standby-skeleton />
-        </div>
+        </x-loading.visible>
 
-        <div class="w-full" wire:loading.remove>
+        <x-loading.hidden>
             <x-delegates.table-desktop-standby :delegates="$delegates" />
             <x-delegates.table-mobile-standby :delegates="$delegates" />
-        </div>
+        </x-loading.hidden>
     @endif
 
     @if($this->state['status'] === 'active')
-        <div class="w-full" wire:loading>
+        <x-loading.visible>
             <x-delegates.table-desktop-active-skeleton />
             <x-delegates.table-mobile-active-skeleton />
-        </div>
+        </x-loading.visible>
 
-        <div class="w-full" wire:loading.remove>
+        <x-loading.hidden>
             <x-delegates.table-desktop-active :delegates="$delegates" />
             <x-delegates.table-mobile-active :delegates="$delegates" />
-        </div>
+        </x-loading.hidden>
     @endif
 
     <script>

--- a/resources/views/livewire/monitor-network.blade.php
+++ b/resources/views/livewire/monitor-network.blade.php
@@ -28,15 +28,15 @@
         </div>
     </div>
 
-    <div class="w-full" wire:loading>
+    <x-loading.visible>
         <x-delegates.table-desktop-monitor-skeleton />
 
         <x-delegates.table-mobile-monitor-skeleton />
-    </div>
+    </x-loading.visible>
 
-    <div class="w-full" wire:loading.remove>
+    <x-loading.hidden>
         <x-delegates.table-desktop-monitor :delegates="$delegates" />
 
         {{-- <x-delegates.table-mobile-monitor-skeleton :delegates="$delegates" /> --}}
-    </div>
+    </x-loading.hidden>
 </div>

--- a/resources/views/livewire/tables/blocks.blade.php
+++ b/resources/views/livewire/tables/blocks.blade.php
@@ -1,11 +1,5 @@
 <div id="block-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-blocks.table-desktop-skeleton />
-
-        <x-blocks.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.blocks>
         <x-blocks.table-desktop :blocks="$blocks" />
 
         <x-blocks.table-mobile :blocks="$blocks" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#block-list')));
         </script>
-    </div>
+    </x-skeletons.blocks>
 </div>

--- a/resources/views/livewire/tables/transactions.blade.php
+++ b/resources/views/livewire/tables/transactions.blade.php
@@ -1,11 +1,5 @@
 <div id="transaction-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-transactions.table-desktop-skeleton />
-
-        <x-transactions.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.transactions>
         <x-transactions.table-desktop :transactions="$transactions" />
 
         <x-transactions.table-mobile :transactions="$transactions" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#transaction-list')));
         </script>
-    </div>
+    </x-skeletons.transactions>
 </div>

--- a/resources/views/livewire/tables/wallets.blade.php
+++ b/resources/views/livewire/tables/wallets.blade.php
@@ -1,11 +1,5 @@
 <div id="wallet-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-wallets.table-desktop-skeleton />
-
-        <x-wallets.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.wallets>
         <x-wallets.table-desktop :wallets="$wallets" />
 
         <x-wallets.table-mobile :wallets="$wallets" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#wallet-list')));
         </script>
-    </div>
+    </x-skeletons.wallets>
 </div>

--- a/resources/views/livewire/transaction-table.blade.php
+++ b/resources/views/livewire/transaction-table.blade.php
@@ -1,11 +1,5 @@
 <div id="transaction-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-transactions.table-desktop-skeleton />
-
-        <x-transactions.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.transactions>
         <x-transactions.table-desktop :transactions="$transactions" />
 
         <x-transactions.table-mobile :transactions="$transactions" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#transaction-list')));
         </script>
-    </div>
+    </x-skeletons.transactions>
 </div>

--- a/resources/views/livewire/wallet-block-table.blade.php
+++ b/resources/views/livewire/wallet-block-table.blade.php
@@ -1,11 +1,5 @@
 <div id="block-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-blocks.table-desktop-skeleton />
-
-        <x-blocks.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.blocks>
         <x-blocks.table-desktop :blocks="$blocks" />
 
         <x-blocks.table-mobile :blocks="$blocks" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#block-list')));
         </script>
-    </div>
+    </x-skeletons.blocks>
 </div>

--- a/resources/views/livewire/wallet-table.blade.php
+++ b/resources/views/livewire/wallet-table.blade.php
@@ -1,11 +1,5 @@
 <div id="wallet-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-wallets.table-desktop-skeleton />
-
-        <x-wallets.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.wallets>
         <x-wallets.table-desktop :wallets="$wallets" />
 
         <x-wallets.table-mobile :wallets="$wallets" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#wallet-list')));
         </script>
-    </div>
+    </x-skeletons.wallets>
 </div>

--- a/resources/views/livewire/wallet-transaction-table.blade.php
+++ b/resources/views/livewire/wallet-transaction-table.blade.php
@@ -62,13 +62,7 @@
     </div>
 
     <div id="transaction-list" class="w-full">
-        <div class="w-full" wire:loading>
-            <x-transactions.table-desktop-skeleton use-confirmations use-direction />
-
-            <x-transactions.table-mobile-skeleton />
-        </div>
-
-        <div class="w-full" wire:loading.remove>
+        <x-skeletons.transactions>
             <x-transactions.table-desktop :transactions="$transactions" :wallet="$wallet" use-confirmations use-direction />
 
             <x-transactions.table-mobile :transactions="$transactions" />
@@ -78,6 +72,6 @@
             <script>
                 window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#transaction-list')));
             </script>
-        </div>
+        </x-skeletons.transactions>
     </div>
 </div>

--- a/resources/views/livewire/wallet-voter-table.blade.php
+++ b/resources/views/livewire/wallet-voter-table.blade.php
@@ -1,11 +1,5 @@
 <div id="block-list" class="w-full">
-    <div class="w-full" wire:loading>
-        <x-wallets.table-desktop-skeleton />
-
-        <x-wallets.table-mobile-skeleton />
-    </div>
-
-    <div class="w-full" wire:loading.remove>
+    <x-skeletons.wallets>
         <x-wallets.table-desktop :wallets="$wallets" />
 
         <x-wallets.table-mobile :wallets="$wallets" />
@@ -15,5 +9,5 @@
         <script>
             window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#block-list')));
         </script>
-    </div>
+    </x-skeletons.wallets>
 </div>


### PR DESCRIPTION
Introduces the `loading.visible` and `loading.hidden` components to easily show and hide content depending on the state of `wire:loading`. Also introduces a few wrapper components for blocks, transactions and wallets to keep the behaviours consistent across pages.