### PR TITLE
perf: eager-load block of transactions owned by a specific wallet

### DIFF
--- a/app/Http/Livewire/WalletTransactionTable.php
+++ b/app/Http/Livewire/WalletTransactionTable.php
@@ -73,8 +73,7 @@ final class WalletTransactionTable extends Component
 
     private function getAllQuery(): Builder
     {
-        $query = Transaction::query();
-        $query->with('block');
+        $query = Transaction::with('block');
 
         $query->where(function ($query): void {
             $query->where('sender_public_key', $this->state['publicKey']);
@@ -99,8 +98,7 @@ final class WalletTransactionTable extends Component
 
     private function getReceivedQuery(): Builder
     {
-        $query = Transaction::query();
-        $query->with('block');
+        $query = Transaction::with('block');
 
         $query->where(function ($query): void {
             $query->where('recipient_id', $this->state['address']);
@@ -119,12 +117,9 @@ final class WalletTransactionTable extends Component
 
     private function getSentQuery(): Builder
     {
-        $query = Transaction::query();
-        $query->with('block');
+        $query = Transaction::with('block');
 
-        $this->applyTypeScope(Transaction::where('sender_public_key', $this->state['publicKey']));
-
-        return $query;
+        return $this->applyTypeScope(Transaction::where('sender_public_key', $this->state['publicKey']));
     }
 
     private function applyTypeScope(Builder $query): Builder

--- a/app/Http/Livewire/WalletTransactionTable.php
+++ b/app/Http/Livewire/WalletTransactionTable.php
@@ -9,8 +9,8 @@ use App\Http\Livewire\Concerns\ManagesTransactionTypeScopes;
 use App\Models\Transaction;
 use App\ViewModels\ViewModelFactory;
 use ARKEcosystem\UserInterface\Http\Livewire\Concerns\HasPagination;
+use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\View\View;
 use Livewire\Component;
 
 final class WalletTransactionTable extends Component
@@ -74,6 +74,7 @@ final class WalletTransactionTable extends Component
     private function getAllQuery(): Builder
     {
         $query = Transaction::query();
+        $query->with('block');
 
         $query->where(function ($query): void {
             $query->where('sender_public_key', $this->state['publicKey']);
@@ -99,6 +100,7 @@ final class WalletTransactionTable extends Component
     private function getReceivedQuery(): Builder
     {
         $query = Transaction::query();
+        $query->with('block');
 
         $query->where(function ($query): void {
             $query->where('recipient_id', $this->state['address']);
@@ -117,7 +119,12 @@ final class WalletTransactionTable extends Component
 
     private function getSentQuery(): Builder
     {
-        return $this->applyTypeScope(Transaction::where('sender_public_key', $this->state['publicKey']));
+        $query = Transaction::query();
+        $query->with('block');
+
+        $this->applyTypeScope(Transaction::where('sender_public_key', $this->state['publicKey']));
+
+        return $query;
     }
 
     private function applyTypeScope(Builder $query): Builder

--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -29,6 +29,13 @@ final class Block extends Model
     use HasFactory;
 
     /**
+     * The "type" of the primary key ID.
+     *
+     * @var string
+     */
+    public $keyType = 'string';
+
+    /**
      * Indicates if the IDs are auto-incrementing.
      *
      * @var bool
@@ -48,8 +55,6 @@ final class Block extends Model
         'total_amount'           => BigInteger::class,
         'total_fee'              => BigInteger::class,
     ];
-
-    public $keyType = 'string';
 
     // /**
     //  * The relations to eager load on every query.

--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -49,6 +49,8 @@ final class Block extends Model
         'total_fee'              => BigInteger::class,
     ];
 
+    public $keyType = 'string';
+
     // /**
     //  * The relations to eager load on every query.
     //  *

--- a/app/Services/Transactions/TransactionState.php
+++ b/app/Services/Transactions/TransactionState.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Services\Transactions;
 
-use App\Facades\Blocks;
 use App\Facades\Network;
 use App\Models\Transaction;
 use App\Services\Cache\NetworkCache;

--- a/app/Services/Transactions/TransactionState.php
+++ b/app/Services/Transactions/TransactionState.php
@@ -21,7 +21,7 @@ final class TransactionState
     public function isConfirmed(): bool
     {
         try {
-            $block = Blocks::findById($this->transaction->block_id);
+            $block = $this->transaction->block;
 
             $confirmations = (new NetworkCache())->getHeight() - $block->height->toNumber();
 

--- a/app/Services/Transactions/TransactionState.php
+++ b/app/Services/Transactions/TransactionState.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Transactions;
 
 use App\Facades\Network;
+use App\Models\Block;
 use App\Models\Transaction;
 use App\Services\Cache\NetworkCache;
 
@@ -20,6 +21,7 @@ final class TransactionState
     public function isConfirmed(): bool
     {
         try {
+            /** @var Block $block */
             $block = $this->transaction->block;
 
             $confirmations = (new NetworkCache())->getHeight() - $block->height->toNumber();

--- a/app/ViewModels/TransactionViewModel.php
+++ b/app/ViewModels/TransactionViewModel.php
@@ -6,6 +6,7 @@ namespace App\ViewModels;
 
 use App\Contracts\ViewModel;
 use App\Facades\Wallets;
+use App\Models\Block;
 use App\Models\Transaction;
 use App\Services\Cache\NetworkCache;
 use App\Services\ExchangeRate;
@@ -99,6 +100,7 @@ final class TransactionViewModel implements ViewModel
     public function confirmations(): int
     {
         try {
+            /** @var Block $block */
             $block = $this->transaction->block;
 
             return abs(( new NetworkCache())->getHeight() - $block->height->toNumber());

--- a/app/ViewModels/TransactionViewModel.php
+++ b/app/ViewModels/TransactionViewModel.php
@@ -100,7 +100,7 @@ final class TransactionViewModel implements ViewModel
     public function confirmations(): int
     {
         try {
-            $block = Blocks::findById($this->transaction->block_id);
+            $block = $this->transaction->block;
 
             return abs(( new NetworkCache())->getHeight() - $block->height->toNumber());
         } catch (\Throwable $th) {

--- a/app/ViewModels/TransactionViewModel.php
+++ b/app/ViewModels/TransactionViewModel.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\ViewModels;
 
 use App\Contracts\ViewModel;
-use App\Facades\Blocks;
 use App\Facades\Wallets;
 use App\Models\Transaction;
 use App\Services\Cache\NetworkCache;

--- a/tests/Feature/Http/Livewire/WalletTransactionTableTest.php
+++ b/tests/Feature/Http/Livewire/WalletTransactionTableTest.php
@@ -226,7 +226,8 @@ it('should apply directions through an event', function () {
     ]);
 
     $received = Transaction::factory()->create([
-        'recipient_id' => $this->subject->address,
+        'sender_public_key' => '03bbfb43ecb5a54a1e227bb37b5812b5321213838d376e2b455b6af78442621dec',
+        'recipient_id'      => $this->subject->address,
     ]);
 
     $component = Livewire::test(WalletTransactionTable::class, [$this->subject->address, $this->subject->public_key]);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->
Reduces 15 queries (1 for fetching each block) to a single one that loads them all beforehand.

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
