### PR TITLE
perf: use `block_height` for confirmations instead of hitting the database

### DIFF
--- a/app/Http/Livewire/Concerns/ManagesLatestTransactions.php
+++ b/app/Http/Livewire/Concerns/ManagesLatestTransactions.php
@@ -21,7 +21,7 @@ trait ManagesLatestTransactions
     public function pollTransactions(): void
     {
         $this->transactions = (new TableCache())->setLatestTransactions($this->state['type'], function () {
-            $query = Transaction::with('block')->latestByTimestamp();
+            $query = Transaction::latestByTimestamp();
 
             if ($this->state['type'] !== 'all') {
                 $scopeClass = $this->scopes[$this->state['type']];

--- a/app/Http/Livewire/WalletTransactionTable.php
+++ b/app/Http/Livewire/WalletTransactionTable.php
@@ -73,7 +73,7 @@ final class WalletTransactionTable extends Component
 
     private function getAllQuery(): Builder
     {
-        $query = Transaction::with('block');
+        $query = Transaction::query();
 
         $query->where(function ($query): void {
             $query->where('sender_public_key', $this->state['publicKey']);
@@ -98,7 +98,7 @@ final class WalletTransactionTable extends Component
 
     private function getReceivedQuery(): Builder
     {
-        $query = Transaction::with('block');
+        $query = Transaction::query();
 
         $query->where(function ($query): void {
             $query->where('recipient_id', $this->state['address']);
@@ -117,9 +117,7 @@ final class WalletTransactionTable extends Component
 
     private function getSentQuery(): Builder
     {
-        return $this
-            ->applyTypeScope(Transaction::where('sender_public_key', $this->state['publicKey']))
-            ->with('block');
+        return $this->applyTypeScope(Transaction::where('sender_public_key', $this->state['publicKey']));
     }
 
     private function applyTypeScope(Builder $query): Builder

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -22,7 +22,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $block_id
  * @property string|null $recipient_id
  * @property string $sender_public_key
- * @property string $block_height
+ * @property int $block_height
  */
 final class Transaction extends Model
 {
@@ -55,7 +55,7 @@ final class Transaction extends Model
         'timestamp'    => 'int',
         'type_group'   => 'int',
         'type'         => 'int',
-        'block_height' => 'string',
+        'block_height' => 'int',
     ];
 
     /**

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -22,6 +22,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $block_id
  * @property string|null $recipient_id
  * @property string $sender_public_key
+ * @property string $block_height
  */
 final class Transaction extends Model
 {
@@ -48,12 +49,13 @@ final class Transaction extends Model
      * @var array
      */
     protected $casts = [
-        'amount'     => BigInteger::class,
-        'asset'      => 'array',
-        'fee'        => BigInteger::class,
-        'timestamp'  => 'int',
-        'type_group' => 'int',
-        'type'       => 'int',
+        'amount'       => BigInteger::class,
+        'asset'        => 'array',
+        'fee'          => BigInteger::class,
+        'timestamp'    => 'int',
+        'type_group'   => 'int',
+        'type'         => 'int',
+        'block_height' => 'string',
     ];
 
     /**

--- a/app/ViewModels/TransactionViewModel.php
+++ b/app/ViewModels/TransactionViewModel.php
@@ -6,7 +6,6 @@ namespace App\ViewModels;
 
 use App\Contracts\ViewModel;
 use App\Facades\Wallets;
-use App\Models\Block;
 use App\Models\Transaction;
 use App\Services\Cache\NetworkCache;
 use App\Services\ExchangeRate;
@@ -99,13 +98,6 @@ final class TransactionViewModel implements ViewModel
 
     public function confirmations(): int
     {
-        try {
-            /** @var Block $block */
-            $block = $this->transaction->block;
-
-            return abs(( new NetworkCache())->getHeight() - $block->height->toNumber());
-        } catch (\Throwable $th) {
-            return 0;
-        }
+        return abs((new NetworkCache())->getHeight() - $this->transaction->block_height);
     }
 }

--- a/app/ViewModels/TransactionViewModel.php
+++ b/app/ViewModels/TransactionViewModel.php
@@ -98,6 +98,6 @@ final class TransactionViewModel implements ViewModel
 
     public function confirmations(): int
     {
-        return abs((new NetworkCache())->getHeight() - $this->transaction->block_height);
+        return (int) abs((new NetworkCache())->getHeight() - $this->transaction->block_height);
     }
 }

--- a/app/ViewModels/TransactionViewModel.php
+++ b/app/ViewModels/TransactionViewModel.php
@@ -98,6 +98,6 @@ final class TransactionViewModel implements ViewModel
 
     public function confirmations(): int
     {
-        return (int) abs((new NetworkCache())->getHeight() - $this->transaction->block_height);
+        return abs((new NetworkCache())->getHeight() - $this->transaction->block_height);
     }
 }

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -18,6 +18,7 @@ final class TransactionFactory extends Factory
         return [
             'id'                => $this->faker->uuid,
             'block_id'          => fn () => Block::factory(),
+            'block_height'      => $this->faker->numberBetween(1, 10000),
             'type'              => $this->faker->numberBetween(1, 100),
             'type_group'        => $this->faker->numberBetween(1, 100),
             'sender_public_key' => fn () => Wallet::factory()->create()->public_key,

--- a/tests/Unit/ViewModels/TransactionViewModelTest.php
+++ b/tests/Unit/ViewModels/TransactionViewModelTest.php
@@ -29,6 +29,7 @@ beforeEach(function () {
 
     $this->subject = new TransactionViewModel(Transaction::factory()->create([
         'block_id'          => $this->block->id,
+        'block_height'      => 1,
         'fee'               => '100000000',
         'amount'            => '200000000',
         'sender_public_key' => Wallet::factory()->create(['address' => 'D6Z26L69gdk9qYmTv5uzk3uGepigtHY4ax'])->public_key,
@@ -612,15 +613,6 @@ it('should determine the type icon', function () {
 
 it('should determine the direction icon', function () {
     expect($this->subject->iconDirection('sender'))->toBeString();
-});
-
-it('should fail to get the confirmations', function () {
-    $this->subject = new TransactionViewModel(Transaction::factory()->create([
-        'block_id' => 'unknown',
-    ]));
-
-    expect($this->subject->confirmations())->toBeInt();
-    expect($this->subject->confirmations())->toBe(0);
 });
 
 it('should fallback to the sender if no recipient exists', function () {

--- a/tests/migrations/2020_10_19_042110_create_transactions_table.php
+++ b/tests/migrations/2020_10_19_042110_create_transactions_table.php
@@ -13,6 +13,7 @@ final class CreateTransactionsTable extends Migration
         Schema::create('transactions', function (Blueprint $table) {
             $table->string('id');
             $table->string('block_id');
+            $table->string('block_height');
             $table->unsignedBigInteger('type');
             $table->unsignedBigInteger('type_group');
             $table->string('sender_public_key');


### PR DESCRIPTION
Core 3.0 has a new column called `block_height` for transactions which contains the height of the block in which the transaction was included.