### PR TITLE
fix: remove `?` from URL if search is empty

### DIFF
--- a/app/Http/Livewire/SearchModule.php
+++ b/app/Http/Livewire/SearchModule.php
@@ -22,7 +22,9 @@ final class SearchModule extends Component
     public bool $isSlim = false;
 
     /** @phpstan-ignore-next-line */
-    protected $queryString = ['state'];
+    protected $queryString = [
+        'state' => ['except' => []],
+    ];
 
     public function mount(bool $isSlim = false): void
     {


### PR DESCRIPTION
https://app.clickup.com/t/9wrn12