### PR TITLE
fix: properly remove the active state of the delegates tabs when clicking on monitor one

### DIFF
--- a/resources/views/livewire/monitor-delegate-tabs.blade.php
+++ b/resources/views/livewire/monitor-delegate-tabs.blade.php
@@ -2,7 +2,7 @@
     <div class="flex w-10/12 tabs">
         <div
             class="tab-item transition-default"
-            :class="{ 'tab-item-current': status === 'active' }"
+            :class="{ 'tab-item-current': status === 'active' && component !== 'monitor' }"
             wire:click="$emit('filterByDelegateStatus', 'active');"
             @click="component = 'list'; status = 'active'"
         >
@@ -15,7 +15,7 @@
 
         <div
             class="tab-item transition-default"
-            :class="{ 'tab-item-current': status === 'standby' }"
+            :class="{ 'tab-item-current': status === 'standby' && component !== 'monitor' }"
             wire:click="$emit('filterByDelegateStatus', 'standby');"
             @click="component = 'list'; status = 'standby'"
         >
@@ -26,7 +26,7 @@
 
         <div
             class="tab-item transition-default"
-            :class="{ 'tab-item-current': status === 'resigned' }"
+            :class="{ 'tab-item-current': status === 'resigned' && component !== 'monitor' }"
             wire:click="$emit('filterByDelegateStatus', 'resigned');"
             @click="component = 'list'; status = 'resigned'"
         >


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/9wrekv

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged