### PR TITLE
fix: transaction filter issue

### DIFF
--- a/app/Http/Controllers/TransactionsController.php
+++ b/app/Http/Controllers/TransactionsController.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Transaction;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+final class TransactionsController
+{
+    public function __invoke(Request $request, Transaction $transaction): View
+    {
+        $type = $request->input('state.type', 'all');
+
+        return view('transactions', [
+            'transactionTypeFilter' => $type,
+        ]);
+    }
+}

--- a/app/Http/Controllers/TransactionsController.php
+++ b/app/Http/Controllers/TransactionsController.php
@@ -12,7 +12,7 @@ final class TransactionsController
 {
     public function __invoke(Request $request, Transaction $transaction): View
     {
-        $type = $request->input('type', 'all');
+        $type = $request->input('state.type', 'all');
 
         return view('transactions', [
             'transactionTypeFilter' => $type,

--- a/app/Http/Controllers/TransactionsController.php
+++ b/app/Http/Controllers/TransactionsController.php
@@ -12,7 +12,7 @@ final class TransactionsController
 {
     public function __invoke(Request $request, Transaction $transaction): View
     {
-        $type = $request->input('state.type', 'all');
+        $type = $request->input('type', 'all');
 
         return view('transactions', [
             'transactionTypeFilter' => $type,

--- a/app/Http/Livewire/LatestRecords.php
+++ b/app/Http/Livewire/LatestRecords.php
@@ -44,8 +44,8 @@ final class LatestRecords extends Component
         }
 
         return view('livewire.latest-records', [
-                'blocks' => ViewModelFactory::collection($this->blocks),
-            ]);
+            'blocks' => ViewModelFactory::collection($this->blocks),
+        ]);
     }
 
     private function renderTransactions(): View

--- a/app/Http/Livewire/LatestRecords.php
+++ b/app/Http/Livewire/LatestRecords.php
@@ -44,8 +44,8 @@ final class LatestRecords extends Component
         }
 
         return view('livewire.latest-records', [
-            'blocks' => ViewModelFactory::collection($this->blocks),
-        ]);
+                'blocks' => ViewModelFactory::collection($this->blocks),
+            ]);
     }
 
     private function renderTransactions(): View

--- a/app/Http/Livewire/TransactionTable.php
+++ b/app/Http/Livewire/TransactionTable.php
@@ -8,7 +8,7 @@ use App\Models\Scopes\OrderByTimestampScope;
 use App\Models\Transaction;
 use App\ViewModels\ViewModelFactory;
 use ARKEcosystem\UserInterface\Http\Livewire\Concerns\HasPagination;
-use Illuminate\View\View;
+use Illuminate\Contracts\View\View;
 use Livewire\Component;
 
 final class TransactionTable extends Component
@@ -29,6 +29,13 @@ final class TransactionTable extends Component
         $this->gotoPage(1);
     }
 
+    public function mount(): void
+    {
+        $this->state = array_merge([
+            'type'        => 'all',
+        ], request('state', []));
+    }
+
     public function render(): View
     {
         $query = Transaction::withScope(OrderByTimestampScope::class);
@@ -36,7 +43,6 @@ final class TransactionTable extends Component
         if ($this->state['type'] !== 'all') {
             $scopeClass = Transaction::TYPE_SCOPES[$this->state['type']];
 
-            /* @var \Illuminate\Database\Eloquent\Model */
             $query = $query->withScope($scopeClass);
         }
 

--- a/resources/views/components/transaction-table-filter.blade.php
+++ b/resources/views/components/transaction-table-filter.blade.php
@@ -1,7 +1,7 @@
 <div x-data="{
     filterOpen: false,
-    transactionTypeFilter: 'all',
-    transactionTypeFilterLabel: 'All',
+    transactionTypeFilter: '{{ $type }}',
+    transactionTypeFilterLabel: '@lang('forms.search.transaction_types.' . $type)',
 }" x-cloak>
     <x-ark-dropdown
         wrapper-class="transaction-filter-wrapper"

--- a/resources/views/components/wallet/transactions.blade.php
+++ b/resources/views/components/wallet/transactions.blade.php
@@ -3,8 +3,8 @@
         <div x-data="{
             dropdownOpen: false,
             direction: 'all',
-            transactionTypeFilter: 'all',
-            transactionTypeFilterLabel: 'All',
+            transactionTypeFilter: '{{ $state["type"] }}',
+            transactionTypeFilterLabel: "@lang('forms.search.transaction_types.' . $state['type'])",
         }" x-cloak class="w-full">
             <div class="w-full md:mb-8">
                 <div class="relative flex flex-col justify-between md:items-end md:flex-row md:justify-start">

--- a/resources/views/components/wallet/transactions.blade.php
+++ b/resources/views/components/wallet/transactions.blade.php
@@ -3,14 +3,14 @@
         <div x-data="{
             dropdownOpen: false,
             direction: 'all',
-            transactionTypeFilter: '{{ $state["type"] }}',
-            transactionTypeFilterLabel: "@lang('forms.search.transaction_types.' . $state['type'])",
+            transactionTypeFilter: 'all',
+            transactionTypeFilterLabel: 'All',
         }" x-cloak class="w-full">
             <div class="w-full md:mb-8">
                 <div class="relative flex flex-col justify-between md:items-end md:flex-row md:justify-start">
                     <h2 class="mb-8 text-2xl md:mb-0">@lang('pages.wallet.transaction_history')</h2>
 
-                    <x-transaction-table-filter :type="$state['type']"/>
+                    <x-transaction-table-filter :type="'all'" />
                 </div>
             </div>
 

--- a/resources/views/components/wallet/transactions.blade.php
+++ b/resources/views/components/wallet/transactions.blade.php
@@ -10,7 +10,7 @@
                 <div class="relative flex flex-col justify-between md:items-end md:flex-row md:justify-start">
                     <h2 class="mb-8 text-2xl md:mb-0">@lang('pages.wallet.transaction_history')</h2>
 
-                    <x-transaction-table-filter />
+                    <x-transaction-table-filter :type="$state['type']"/>
                 </div>
             </div>
 

--- a/resources/views/livewire/latest-records.blade.php
+++ b/resources/views/livewire/latest-records.blade.php
@@ -98,7 +98,7 @@
                     <x-tables.mobile.transactions :transactions="$transactions" />
 
                     <div class="pt-4 mt-8 border-t border-theme-secondary-300 dark:border-theme-secondary-800 md:mt-0 md:border-dashed">
-                        <a href="{{ route('transactions', ['page' => 2, 'type' => $state['type']]) }}" class="w-full button-secondary">@lang('actions.view_all')</a>
+                        <a href="{{ route('transactions', ['page' => 2, 'state[type]' => $state['type']]) }}" class="w-full button-secondary">@lang('actions.view_all')</a>
                     </div>
                 </div>
             @endif

--- a/resources/views/livewire/latest-records.blade.php
+++ b/resources/views/livewire/latest-records.blade.php
@@ -98,7 +98,7 @@
                     <x-tables.mobile.transactions :transactions="$transactions" />
 
                     <div class="pt-4 mt-8 border-t border-theme-secondary-300 dark:border-theme-secondary-800 md:mt-0 md:border-dashed">
-                        <a href="{{ route('transactions', ['page' => 2]) }}" class="w-full button-secondary">@lang('actions.view_all')</a>
+                        <a href="{{ route('transactions', ['page' => 2, 'state[type]' => $state['type']]) }}" class="w-full button-secondary">@lang('actions.view_all')</a>
                     </div>
                 </div>
             @endif

--- a/resources/views/livewire/latest-records.blade.php
+++ b/resources/views/livewire/latest-records.blade.php
@@ -98,7 +98,7 @@
                     <x-tables.mobile.transactions :transactions="$transactions" />
 
                     <div class="pt-4 mt-8 border-t border-theme-secondary-300 dark:border-theme-secondary-800 md:mt-0 md:border-dashed">
-                        <a href="{{ route('transactions', ['page' => 2, 'state[type]' => $state['type']]) }}" class="w-full button-secondary">@lang('actions.view_all')</a>
+                        <a href="{{ route('transactions', ['page' => 2, 'type' => $state['type']]) }}" class="w-full button-secondary">@lang('actions.view_all')</a>
                     </div>
                 </div>
             @endif

--- a/resources/views/livewire/latest-records.blade.php
+++ b/resources/views/livewire/latest-records.blade.php
@@ -9,7 +9,7 @@
             <h2 class="mb-8 text-3xl md:mb-0 sm:text-4xl">@lang('pages.home.transactions_and_blocks')</h2>
 
             <div x-show="selected === 'transactions'">
-                <x-transaction-table-filter />
+                <x-transaction-table-filter :type="$state['type']"/>
             </div>
         </div>
     </div>

--- a/resources/views/livewire/latest-records.blade.php
+++ b/resources/views/livewire/latest-records.blade.php
@@ -1,8 +1,8 @@
 <div x-data="{
     tabsOpen: false,
     selected: 'transactions',
-    transactionTypeFilter: 'all',
-    transactionTypeFilterLabel: 'All',
+    transactionTypeFilter: '{{ $state["type"] }}',
+    transactionTypeFilterLabel: '@lang('forms.search.transaction_types.' . $state['type'])',
 }" x-cloak class="w-full">
     <div class="w-full md:mb-8">
         <div class="relative flex flex-col justify-between md:items-end md:flex-row md:justify-start">

--- a/resources/views/transactions.blade.php
+++ b/resources/views/transactions.blade.php
@@ -7,8 +7,8 @@
             <div class="py-16 content-container md:px-8">
                 <div x-data="{
                     dropdownOpen: false,
-                    transactionTypeFilter: 'all',
-                    transactionTypeFilterLabel: 'All',
+                    transactionTypeFilter: '{{ $transactionTypeFilter }}',
+                    transactionTypeFilterLabel: '@lang('forms.search.transaction_types.' . $transactionTypeFilter)',
                 }" x-cloak class="w-full">
                     <div class="w-full mb-8">
                         <div class="relative flex flex-col justify-between md:items-end md:flex-row md:justify-start">

--- a/resources/views/transactions.blade.php
+++ b/resources/views/transactions.blade.php
@@ -15,7 +15,7 @@
                             <h2 class="mb-8 text-3xl md:mb-0 sm:text-4xl">@lang('pages.transactions.title')</h2>
 
                             <div>
-                                <x-transaction-table-filter />
+                                <x-transaction-table-filter :type="$transactionTypeFilter"/>
                             </div>
                         </div>
                     </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ListVotersByWalletController;
 use App\Http\Controllers\ShowBlockController;
 use App\Http\Controllers\ShowTransactionController;
 use App\Http\Controllers\ShowWalletController;
+use App\Http\Controllers\TransactionsController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -28,7 +29,7 @@ Route::view('/delegates', 'app.delegates')->name('delegates');
 Route::view('/blocks', 'blocks')->name('blocks');
 Route::get('/blocks/{block}', ShowBlockController::class)->name('block');
 
-Route::view('/transactions', 'transactions')->name('transactions');
+Route::get('/transactions', TransactionsController::class)->name('transactions');
 Route::get('/transactions/{transaction}', ShowTransactionController::class)->name('transaction');
 
 Route::view('/wallets', 'app.wallets')->name('wallets');

--- a/tests/Feature/Http/Controllers/TransactionsControllerTest.php
+++ b/tests/Feature/Http/Controllers/TransactionsControllerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+it('should render the page without any errors', function () {
+    $this
+        ->get(route('transactions'))
+        ->assertOk()
+        ->assertViewHas('transactionTypeFilter', 'all');
+});
+
+it('should render the page with given transaction type', function () {
+    $this
+        ->get(route('transactions', ['type'=>'multiPayment']))
+        ->assertOk()
+        ->assertViewHas('transactionTypeFilter', 'multiPayment');
+});

--- a/tests/Feature/Http/Controllers/TransactionsControllerTest.php
+++ b/tests/Feature/Http/Controllers/TransactionsControllerTest.php
@@ -11,7 +11,7 @@ it('should render the page without any errors', function () {
 
 it('should render the page with given transaction type', function () {
     $this
-        ->get(route('transactions', ['type'=>'multiPayment']))
+        ->get(route('transactions', ['state[type]' => 'multiPayment']))
         ->assertOk()
         ->assertViewHas('transactionTypeFilter', 'multiPayment');
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->
Changing the Transaction Filter from the dropdown displays a list of transactions for the transaction type. Selecting 'View More' results in the filter changing to 'All' when the selected transaction type should persist.

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
