### PR TITLE
fix: retry delegate polling until we have a list of delegates

### DIFF
--- a/app/Http/Livewire/DelegateMonitor.php
+++ b/app/Http/Livewire/DelegateMonitor.php
@@ -39,27 +39,27 @@ final class DelegateMonitor extends Component
     {
         // $tracking = DelegateTracker::execute(Monitor::roundDelegates(112168));
 
-        $roundNumber = Rounds::currentRound()->round;
-        $heightRange = Monitor::heightRangeByRound($roundNumber);
-        $tracking    = DelegateTracker::execute(Rounds::allByRound($roundNumber));
-        $roundBlocks = $this->getBlocksByRange(Arr::pluck($tracking, 'publicKey'), $heightRange);
+        try {
+            $roundNumber = Rounds::currentRound()->round;
+            $heightRange = Monitor::heightRangeByRound($roundNumber);
+            $tracking    = DelegateTracker::execute(Rounds::allByRound($roundNumber));
+            $roundBlocks = $this->getBlocksByRange(Arr::pluck($tracking, 'publicKey'), $heightRange);
 
-        $delegates = [];
+            $delegates = [];
 
-        for ($i = 0; $i < count($tracking); $i++) {
-            $delegate = array_values($tracking)[$i];
+            for ($i = 0; $i < count($tracking); $i++) {
+                $delegate = array_values($tracking)[$i];
 
-            $delegates[] = new Slot([
-                'publicKey'  => $delegate['publicKey'],
-                'order'      => $i + 1,
-                'wallet'     => ViewModelFactory::make((new WalletCache())->getDelegate($delegate['publicKey'])),
-                'forging_at' => Timestamp::fromGenesis($roundBlocks->last()->timestamp)->addMilliseconds($delegate['time']),
-                'last_block' => (new WalletCache())->getLastBlock($delegate['publicKey']),
-                'status'     => $delegate['status'],
-            ], $roundBlocks, $roundNumber);
-        }
+                $delegates[] = new Slot([
+                    'publicKey'  => $delegate['publicKey'],
+                    'order'      => $i + 1,
+                    'wallet'     => ViewModelFactory::make((new WalletCache())->getDelegate($delegate['publicKey'])),
+                    'forging_at' => Timestamp::fromGenesis($roundBlocks->last()->timestamp)->addMilliseconds($delegate['time']),
+                    'last_block' => (new WalletCache())->getLastBlock($delegate['publicKey']),
+                    'status'     => $delegate['status'],
+                ], $roundBlocks, $roundNumber);
+            }
 
-        if (count($delegates) > 0) {
             $this->delegates = $delegates;
 
             $this->statistics = [
@@ -68,6 +68,9 @@ final class DelegateMonitor extends Component
                 'currentDelegate' => $this->getCurrentDelegate(),
                 'nextDelegate'    => $this->getNextDelegate(),
             ];
+        } catch (\Throwable $th) {
+            // @README: If any errors occur we want to keep polling until we have a list of delegates
+            $this->pollDelegates();
         }
     }
 

--- a/app/Http/Livewire/DelegateMonitor.php
+++ b/app/Http/Livewire/DelegateMonitor.php
@@ -68,10 +68,12 @@ final class DelegateMonitor extends Component
                 'currentDelegate' => $this->getCurrentDelegate(),
                 'nextDelegate'    => $this->getNextDelegate(),
             ];
+            // @codeCoverageIgnoreStart
         } catch (\Throwable $th) {
             // @README: If any errors occur we want to keep polling until we have a list of delegates
             $this->pollDelegates();
         }
+        // @codeCoverageIgnoreEnd
     }
 
     private function getBlockCount(): string


### PR DESCRIPTION
https://app.clickup.com/t/a0wkx4

This error seems to be caused by the delay between core calculating the round and delegates and actually inserting it into the database and without retrying we get stuck on that error because we already calculated the round height and are looking for matching data.