### PR TITLE
refactor: return current round number instead of model instance

### DIFF
--- a/app/Contracts/RoundRepository.php
+++ b/app/Contracts/RoundRepository.php
@@ -4,12 +4,11 @@ declare(strict_types=1);
 
 namespace App\Contracts;
 
-use App\Models\Round;
 use Illuminate\Support\Collection;
 
 interface RoundRepository
 {
     public function allByRound(int $round): Collection;
 
-    public function currentRound(): Round;
+    public function currentRoundNumber(): int;
 }

--- a/app/Contracts/RoundRepository.php
+++ b/app/Contracts/RoundRepository.php
@@ -10,5 +10,5 @@ interface RoundRepository
 {
     public function allByRound(int $round): Collection;
 
-    public function currentRoundNumber(): int;
+    public function current(): int;
 }

--- a/app/Facades/Rounds.php
+++ b/app/Facades/Rounds.php
@@ -10,7 +10,7 @@ use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static Collection allByRound(int $round)
- * @method static int currentRoundNumber()
+ * @method static int current()
  */
 final class Rounds extends Facade
 {

--- a/app/Facades/Rounds.php
+++ b/app/Facades/Rounds.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace App\Facades;
 
 use App\Contracts\RoundRepository;
-use App\Models\Round;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Facade;
 
 /**
  * @method static Collection allByRound(int $round)
- * @method static Round currentRound()
+ * @method static int currentRoundNumber()
  */
 final class Rounds extends Facade
 {

--- a/app/Http/Livewire/DelegateMonitor.php
+++ b/app/Http/Livewire/DelegateMonitor.php
@@ -31,7 +31,7 @@ final class DelegateMonitor extends Component
         return view('livewire.delegate-monitor', [
             'delegates'  => $this->delegates,
             'statistics' => $this->statistics,
-            'round'      => Rounds::currentRound()->round,
+            'round'      => Rounds::currentRoundNumber(),
         ]);
     }
 
@@ -40,7 +40,7 @@ final class DelegateMonitor extends Component
         // $tracking = DelegateTracker::execute(Monitor::roundDelegates(112168));
 
         try {
-            $roundNumber = Rounds::currentRound()->round;
+            $roundNumber = Rounds::currentRoundNumber();
             $heightRange = Monitor::heightRangeByRound($roundNumber);
             $tracking    = DelegateTracker::execute(Rounds::allByRound($roundNumber));
             $roundBlocks = $this->getBlocksByRange(Arr::pluck($tracking, 'publicKey'), $heightRange);

--- a/app/Http/Livewire/DelegateMonitor.php
+++ b/app/Http/Livewire/DelegateMonitor.php
@@ -31,7 +31,7 @@ final class DelegateMonitor extends Component
         return view('livewire.delegate-monitor', [
             'delegates'  => $this->delegates,
             'statistics' => $this->statistics,
-            'round'      => Rounds::currentRoundNumber(),
+            'round'      => Rounds::current(),
         ]);
     }
 
@@ -40,7 +40,7 @@ final class DelegateMonitor extends Component
         // $tracking = DelegateTracker::execute(Monitor::roundDelegates(112168));
 
         try {
-            $roundNumber = Rounds::currentRoundNumber();
+            $roundNumber = Rounds::current();
             $heightRange = Monitor::heightRangeByRound($roundNumber);
             $tracking    = DelegateTracker::execute(Rounds::allByRound($roundNumber));
             $roundBlocks = $this->getBlocksByRange(Arr::pluck($tracking, 'publicKey'), $heightRange);

--- a/app/Repositories/RoundRepository.php
+++ b/app/Repositories/RoundRepository.php
@@ -21,8 +21,8 @@ final class RoundRepository implements Contract
             ->get();
     }
 
-    public function currentRound(): Round
+    public function currentRoundNumber(): int
     {
-        return Round::orderBy('round', 'desc')->firstOrFail();
+        return Round::max('round');
     }
 }

--- a/app/Repositories/RoundRepository.php
+++ b/app/Repositories/RoundRepository.php
@@ -21,7 +21,7 @@ final class RoundRepository implements Contract
             ->get();
     }
 
-    public function currentRoundNumber(): int
+    public function current(): int
     {
         return Round::max('round');
     }

--- a/app/Repositories/RoundRepositoryWithCache.php
+++ b/app/Repositories/RoundRepositoryWithCache.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Repositories;
 
 use App\Contracts\RoundRepository;
-use App\Models\Round;
 use Illuminate\Cache\TaggedCache;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
@@ -26,9 +25,9 @@ final class RoundRepositoryWithCache implements RoundRepository
         return $this->remember(fn () => $this->rounds->allByRound($round));
     }
 
-    public function currentRound(): Round
+    public function currentRoundNumber(): int
     {
-        return $this->remember(fn () => $this->rounds->currentRound());
+        return $this->rounds->currentRoundNumber();
     }
 
     private function getCache(): TaggedCache

--- a/app/Repositories/RoundRepositoryWithCache.php
+++ b/app/Repositories/RoundRepositoryWithCache.php
@@ -25,9 +25,9 @@ final class RoundRepositoryWithCache implements RoundRepository
         return $this->remember(fn () => $this->rounds->allByRound($round));
     }
 
-    public function currentRoundNumber(): int
+    public function current(): int
     {
-        return $this->rounds->currentRoundNumber();
+        return $this->rounds->current();
     }
 
     private function getCache(): TaggedCache

--- a/app/Services/Monitor/Monitor.php
+++ b/app/Services/Monitor/Monitor.php
@@ -11,7 +11,7 @@ final class Monitor
 {
     public static function roundNumber(): int
     {
-        return Rounds::currentRound()->round;
+        return Rounds::currentRoundNumber();
     }
 
     public static function heightRangeByRound(int $round): array

--- a/app/Services/Monitor/Monitor.php
+++ b/app/Services/Monitor/Monitor.php
@@ -11,7 +11,7 @@ final class Monitor
 {
     public static function roundNumber(): int
     {
-        return Rounds::currentRoundNumber();
+        return Rounds::current();
     }
 
     public static function heightRangeByRound(int $round): array

--- a/tests/Unit/Repositories/RoundRepositoryTest.php
+++ b/tests/Unit/Repositories/RoundRepositoryTest.php
@@ -20,5 +20,5 @@ it('should get all delegates for the given round', function () {
 });
 
 it('should get the current round', function () {
-    expect($this->subject->currentRoundNumber())->toBe(Round::max('round'));
+    expect($this->subject->current())->toBe(Round::max('round'));
 });

--- a/tests/Unit/Repositories/RoundRepositoryTest.php
+++ b/tests/Unit/Repositories/RoundRepositoryTest.php
@@ -20,7 +20,5 @@ it('should get all delegates for the given round', function () {
 });
 
 it('should get the current round', function () {
-    Round::factory()->create();
-
-    expect($this->subject->currentRound())->toBeInstanceOf(Round::class);
+    expect($this->subject->currentRoundNumber())->toBe(Round::max('round'));
 });

--- a/tests/Unit/Repositories/RoundRepositoryWithCacheTest.php
+++ b/tests/Unit/Repositories/RoundRepositoryWithCacheTest.php
@@ -23,7 +23,5 @@ it('should get all delegates for the given round', function () {
 });
 
 it('should get the current round', function () {
-    Round::factory()->create();
-
-    expect($this->subject->currentRound())->toBeInstanceOf(Round::class);
+    expect($this->subject->currentRoundNumber())->toBe(Round::max('round'));
 });

--- a/tests/Unit/Repositories/RoundRepositoryWithCacheTest.php
+++ b/tests/Unit/Repositories/RoundRepositoryWithCacheTest.php
@@ -23,5 +23,5 @@ it('should get all delegates for the given round', function () {
 });
 
 it('should get the current round', function () {
-    expect($this->subject->currentRoundNumber())->toBe(Round::max('round'));
+    expect($this->subject->current())->toBe(Round::max('round'));
 });


### PR DESCRIPTION
We should just return the highest round value and not cache it to avoid issues with calculations if the cache refreshes at the wrong time. Spotted by @marianogoldman.