### PR TITLE
fix: only update chart colors when change theme

### DIFF
--- a/resources/views/components/chart.blade.php
+++ b/resources/views/components/chart.blade.php
@@ -36,14 +36,7 @@
             toggleChart() {
                 this.isVisible = ! this.isVisible;
             },
-            updateChart() {
-                this.isDarkTheme = ! this.isDarkTheme;
-
-                this.chart.destroy();
-
-                this.renderChart();
-            },
-            renderChart() {
+            getThemeColors() {
                 let themeColours = {
                     light: {
                         gridLines: "#DBDEE5",
@@ -57,7 +50,32 @@
                     }
                 };
 
-                themeColours = this.isDarkTheme ? themeColours.dark : themeColours.light;
+                return this.isDarkTheme ? themeColours.dark : themeColours.light;
+            },
+            updateChartColors() {
+                this.isDarkTheme = ! this.isDarkTheme;
+
+                const themeColours = this.getThemeColors();
+
+                this.chart.data.datasets.forEach((dataset) => {
+                    dataset.pointBackgroundColor = themeColours.pointBackgroundColor;
+                });
+
+                this.chart.options.scales.yAxes.forEach((yAxe) => {
+                    yAxe.gridLines.color = themeColours.gridLines;
+                    yAxe.ticks.fontColor = themeColours.ticks
+                })
+                this.chart.options.scales.xAxes.forEach((xAxe) => {
+                    xAxe.gridLines.color = themeColours.gridLines;
+                    xAxe.ticks.fontColor = themeColours.ticks
+                })
+
+                this.chart.options.tooltips.titleFontColor = themeColours.ticks;
+
+                this.chart.update();
+            },
+            renderChart() {
+                const themeColours = this.getThemeColors();
 
                 const fontConfig = {
                     fontColor: themeColours.ticks,
@@ -238,7 +256,7 @@
 <div
     x-data="makeChart('{{ $identifier }}', '{{ $coloursScheme }}')"
     x-init="renderChart()"
-    x-on:toggle-dark-mode.window="updateChart()"
+    x-on:toggle-dark-mode.window="updateChartColors()"
     x-on:chart-period-selected.window="setPeriod($event.detail)"
     x-on:{{ $alpineShow }}.window="toggleChart()"
     x-show="isVisible"

--- a/resources/views/components/chart.blade.php
+++ b/resources/views/components/chart.blade.php
@@ -52,9 +52,11 @@
 
                 return this.isDarkTheme ? themeColours.dark : themeColours.light;
             },
-            updateChartColors() {
+            toggleDarkMode() {
                 this.isDarkTheme = ! this.isDarkTheme;
-
+                this.updateChartColors();
+            },
+            updateChartColors() {
                 const themeColours = this.getThemeColors();
 
                 this.chart.data.datasets.forEach((dataset) => {
@@ -256,7 +258,7 @@
 <div
     x-data="makeChart('{{ $identifier }}', '{{ $coloursScheme }}')"
     x-init="renderChart()"
-    x-on:toggle-dark-mode.window="updateChartColors()"
+    x-on:toggle-dark-mode.window="toggleDarkMode()"
     x-on:chart-period-selected.window="setPeriod($event.detail)"
     x-on:{{ $alpineShow }}.window="toggleChart()"
     x-show="isVisible"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/a8r1cy
Instead of refreshing the whole chart now, it changes only the colors, that prevents the error explained on the ticket.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged

<!-- Feel free to add additional comments. -->
