### PR TITLE
fix: remove html spans from no results message

### DIFF
--- a/resources/lang/en/pages.php
+++ b/resources/lang/en/pages.php
@@ -182,13 +182,13 @@ return [
     'blocks_by_wallet' => [
         'title'       => 'Forged Blocks',
         'table_title' => 'Block History',
-        'no_results'  => 'Delegate <span class="font-bold">:0</span> has not yet forged. Once he becomes active his blocks will appear here.',
+        'no_results'  => 'Delegate :0 has not yet forged. Once he becomes active his blocks will appear here.',
     ],
 
     'voters_by_wallet' => [
         'title'      => 'Voting for Delegate',
         'subtitle'   => 'Voters',
-        'no_results' => 'Delegate <span class="font-bold">:0</span> has no voters yet. You can be the first!',
+        'no_results' => 'Delegate :0 has no voters yet. You can be the first!',
     ],
 
     'blocks' => [


### PR DESCRIPTION
we would have to allow html in order to show the delegate name in bold, for now I removed it as I don't want to have unsanitized user data in html