### PR TITLE
chore: change color of the safari pinned tab icon

### DIFF
--- a/resources/views/errors/error.blade.php
+++ b/resources/views/errors/error.blade.php
@@ -31,9 +31,9 @@
     </head>
     <body class="antialiased">
         <div id="app" class="flex flex-col antialiased bg-white theme-light">
-            <main class="container flex items-center flex-1 w-full px-4 mx-auto sm:max-w-full sm:px-8 lg:max-w-7xl">
+            <main class="container flex flex-1 items-center px-4 mx-auto w-full sm:max-w-full sm:px-8 lg:max-w-7xl">
                 <div class="w-full bg-white rounded-lg">
-                    <div class="flex flex-col items-center justify-center space-y-8">
+                    <div class="flex flex-col justify-center items-center space-y-8">
                         <img src="/images/errors/{{ $errorType }}.svg" class="max-w-4xl"/>
                         <div class="text-lg font-semibold text-center text-theme-secondary-900">
                             {{ ARKEcosystem\UserInterface\UI::getErrorMessage($errorType) }}

--- a/resources/views/errors/error.blade.php
+++ b/resources/views/errors/error.blade.php
@@ -11,7 +11,7 @@
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
         <link rel="manifest" href="/site.webmanifest">
-        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#c9292c">
         <meta name="msapplication-TileColor" content="#da532c">
         <meta name="theme-color" content="#ffffff">
 
@@ -31,9 +31,9 @@
     </head>
     <body class="antialiased">
         <div id="app" class="flex flex-col antialiased bg-white theme-light">
-            <main class="container flex flex-1 items-center px-4 mx-auto w-full sm:max-w-full sm:px-8 lg:max-w-7xl">
+            <main class="container flex items-center flex-1 w-full px-4 mx-auto sm:max-w-full sm:px-8 lg:max-w-7xl">
                 <div class="w-full bg-white rounded-lg">
-                    <div class="flex flex-col justify-center items-center space-y-8">
+                    <div class="flex flex-col items-center justify-center space-y-8">
                         <img src="/images/errors/{{ $errorType }}.svg" class="max-w-4xl"/>
                         <div class="text-lg font-semibold text-center text-theme-secondary-900">
                             {{ ARKEcosystem\UserInterface\UI::getErrorMessage($errorType) }}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -53,7 +53,7 @@
                 ]"
             >
                 <x-slot name="logo">
-                    <div class="relative flex items-center">
+                    <div class="flex relative items-center">
                         <img src="/images/logo.svg" class="h-10 lg:h-12" />
 
                         <span class="hidden ml-4 sm:flex text-theme-secondary-900 dark:text-theme-secondary-200 sm:items-center sm:text-2xl">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -14,7 +14,7 @@
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
         <link rel="manifest" href="/site.webmanifest">
-        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+        <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#c9292c">
         <meta name="msapplication-TileColor" content="#da532c">
         <meta name="theme-color" content="#ffffff">
 
@@ -53,7 +53,7 @@
                 ]"
             >
                 <x-slot name="logo">
-                    <div class="flex relative items-center">
+                    <div class="relative flex items-center">
                         <img src="/images/logo.svg" class="h-10 lg:h-12" />
 
                         <span class="hidden ml-4 sm:flex text-theme-secondary-900 dark:text-theme-secondary-200 sm:items-center sm:text-2xl">


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://learn.ark.dev/have-a-question/contribution-guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Changes the color of the icon in tabs on safari to the brand red

Notice that maybe you will need to restart Safari and clear all cache to see the change
https://superuser.com/questions/974909/how-do-i-get-safari-9-to-use-my-new-pinned-tab-icon

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
