### PR TITLE
chore:  upgrade blade icons library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "arkecosystem/fortify": "^3.0",
         "arkecosystem/ui": "^2.0",
         "bacon/bacon-qr-code": "^2.0",
-        "blade-ui-kit/blade-icons": "^0.4.2",
         "brick/math": "^0.9.1",
         "doctrine/dbal": "^2.10",
         "fideloper/proxy": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "arkecosystem/fortify": "^3.0",
         "arkecosystem/ui": "^2.0",
         "bacon/bacon-qr-code": "^2.0",
+        "blade-ui-kit/blade-icons": "^1.0",
         "brick/math": "^0.9.1",
         "doctrine/dbal": "^2.10",
         "fideloper/proxy": "^4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67bdb531e28bff24eb1932510037215c",
+    "content-hash": "f7938246bf2fae53bb79e5869c75e0a6",
     "packages": [
         {
             "name": "arkecosystem/crypto",
@@ -492,30 +492,29 @@
         },
         {
             "name": "blade-ui-kit/blade-icons",
-            "version": "0.4.5",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/blade-ui-kit/blade-icons.git",
-                "reference": "b93505c65a1fc095df517d5640bae295779411e6"
+                "reference": "716c3991efb77389046785ff87a9565aceda8657"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blade-ui-kit/blade-icons/zipball/b93505c65a1fc095df517d5640bae295779411e6",
-                "reference": "b93505c65a1fc095df517d5640bae295779411e6",
+                "url": "https://api.github.com/repos/blade-ui-kit/blade-icons/zipball/716c3991efb77389046785ff87a9565aceda8657",
+                "reference": "716c3991efb77389046785ff87a9565aceda8657",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^7.14|^8.0",
-                "illuminate/filesystem": "^7.14|^8.0",
-                "illuminate/support": "^7.14|^8.0",
-                "illuminate/view": "^7.14|^8.0",
-                "php": "^7.2"
+                "illuminate/contracts": "^8.0",
+                "illuminate/filesystem": "^8.0",
+                "illuminate/support": "^8.0",
+                "illuminate/view": "^8.0",
+                "php": "^7.4|^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.16",
                 "mockery/mockery": "^1.3",
-                "orchestra/testbench": "^5.0|^6.0",
-                "phpunit/phpunit": "^8.0|^9.0"
+                "orchestra/testbench": "^6.0",
+                "phpunit/phpunit": "^9.0"
             },
             "type": "library",
             "extra": {
@@ -539,14 +538,8 @@
             ],
             "authors": [
                 {
-                    "name": "Adam Wathan",
-                    "email": "adam.wathan@gmail.com"
-                },
-                {
                     "name": "Dries Vints",
-                    "email": "dries@vints.io",
-                    "homepage": "https://driesvints.com",
-                    "role": "Developer"
+                    "homepage": "https://driesvints.com"
                 }
             ],
             "description": "A package to easily make use of icons in your Laravel Blade views.",
@@ -563,11 +556,15 @@
             },
             "funding": [
                 {
+                    "url": "https://github.com/caneco",
+                    "type": "github"
+                },
+                {
                     "url": "https://github.com/driesvints",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-04T11:36:46+00:00"
+            "time": "2021-04-03T19:08:34+00:00"
         },
         {
             "name": "brick/math",


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Related to https://app.clickup.com/t/d11nab

~~Removes the blade icons library that is no longer used and is not compatible with php8~~

to make it fully compatible with PHP 8 we still need to update the `arkecosystem/crypto` lib but the conflicting library is the bitcoin library that is not ready for PHP 8 so we need to wait for a little, apparently, they are already  working on it https://github.com/Bit-Wasp/bitcoin-php/issues/879


Update: now upgrades the icons library 

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
