### PR TITLE
fix: toggle error on 404 pages

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Throwable;
 
 final class Handler extends ExceptionHandler
@@ -57,6 +58,19 @@ final class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $exception)
     {
+        if ($this->shouldShow404Page($request, $exception)) {
+            return redirect()->route('error.404');
+        }
+
         return parent::render($request, $exception);
+    }
+
+    private function shouldShow404Page(Request $request, Throwable $exception): bool
+    {
+        $expectedException = $this->prepareException($this->mapException($exception));
+
+        return $request->method() === 'GET'
+            && $expectedException instanceof NotFoundHttpException
+            && ! $request->expectsJson();
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,7 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
+Route::view('404', 'errors.404', [], 404)->name('error.404');
 Route::get('/', HomeController::class)->name('home');
 Route::view('/search', 'app.search-results')->name('search');
 Route::view('/delegates', 'app.delegates')->name('delegates');


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The error is related to the lack of csrf_token on 404 pages needed for livewire actions, this PR redirects any 404 pages to a custom view, the same solution we applied on marketsquare

https://app.clickup.com/t/jvb1qw

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
