### PR TITLE
fix: latest records flaky test

### DIFF
--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Enums\CoreTransactionTypeEnum;
+use App\Enums\TransactionTypeGroupEnum;
 use App\Models\Block;
 use App\Models\Transaction;
 use App\Models\Wallet;
@@ -30,5 +32,13 @@ final class TransactionFactory extends Factory
                 'ipfs' => 'QmXrvSZaDr8vjLUB9b7xz26S3kpk3S3bSc8SUyZmNPvmVo',
             ],
         ];
+    }
+
+    public function transfer(): Factory
+    {
+        return $this->state(fn () => [
+            'type' => CoreTransactionTypeEnum::TRANSFER,
+            'type_group' => TransactionTypeGroupEnum::CORE,
+        ]);
     }
 }

--- a/database/factories/TransactionFactory.php
+++ b/database/factories/TransactionFactory.php
@@ -37,7 +37,7 @@ final class TransactionFactory extends Factory
     public function transfer(): Factory
     {
         return $this->state(fn () => [
-            'type' => CoreTransactionTypeEnum::TRANSFER,
+            'type'       => CoreTransactionTypeEnum::TRANSFER,
             'type_group' => TransactionTypeGroupEnum::CORE,
         ]);
     }

--- a/tests/Feature/Http/Livewire/BlockTransactionsTableTest.php
+++ b/tests/Feature/Http/Livewire/BlockTransactionsTableTest.php
@@ -13,7 +13,7 @@ use Livewire\Livewire;
 
 it('should list the first transactions for the giving block id', function () {
     $block = Block::factory()->create();
-    Transaction::factory(25)->create(['block_id' => $block->id]);
+    Transaction::factory(25)->transfer()->create(['block_id' => $block->id]);
 
     $component = Livewire::test(BlockTransactionsTable::class, ['blockId' => $block->id]);
 

--- a/tests/Feature/Http/Livewire/LatestRecordsTest.php
+++ b/tests/Feature/Http/Livewire/LatestRecordsTest.php
@@ -38,7 +38,7 @@ it('should list the first page of blocks', function () {
 });
 
 it('should list the first page of transactions', function () {
-    Transaction::factory(30)->create();
+    Transaction::factory(30)->transfer()->create();
 
     $component = Livewire::test(LatestRecords::class)
         ->call('pollTransactions');


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge your pull request!
-->

## Summary

https://app.clickup.com/t/kh51ze

The test fails because sometimes, the related address is not being shown based on the transaction type. (see `resources/views/components/transactions/recipient.blade.php`)

The solution: Use a fixed transaction type to have more control over the view.

Update: By coincidence failed another test  on `BlockTransactionsTableTest` for the exact same reason, this PR also fixes that problem

![image](https://user-images.githubusercontent.com/17262776/119755577-daff3780-be67-11eb-8eb7-3edce02a8a80.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
