### PR TITLE
fix: no pointer events for table skeletons

### DIFF
--- a/resources/views/components/tables/skeletons/desktop.blade.php
+++ b/resources/views/components/tables/skeletons/desktop.blade.php
@@ -1,4 +1,4 @@
-<x-ark-tables.table sticky class="hidden w-full md:block">
+<x-ark-tables.table sticky class="hidden w-full pointer-events-none md:block">
     <thead>
         <tr>
             @foreach($headers as $name => $header)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/khcd5c

Remove the hover effect on the skeleton tables by adding the `pointer-events-none` class

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
