### PR TITLE
fix: show proper address skeleton

### DIFF
--- a/resources/views/components/tables/rows/desktop/skeletons/address.blade.php
+++ b/resources/views/components/tables/rows/desktop/skeletons/address.blade.php
@@ -11,7 +11,7 @@
     :first-on="$firstOn"
     :last-on="$lastOn"
 >
-    <div class="flex flex-row-reverse items-center justify-between w-full md:flex-row md:space-x-3 md:justify-start">
+    <div class="flex flex-row-reverse justify-between items-center w-full md:flex-row md:space-x-3 md:justify-start">
         <div>
             <div class="w-6 h-6 rounded-full avatar-wrapper md:w-11 md:h-11 loading-state"></div>
         </div>

--- a/resources/views/components/tables/rows/desktop/skeletons/address.blade.php
+++ b/resources/views/components/tables/rows/desktop/skeletons/address.blade.php
@@ -11,7 +11,7 @@
     :first-on="$firstOn"
     :last-on="$lastOn"
 >
-    <div class="flex flex-row-reverse justify-between items-center md:flex-row md:space-x-3 md:justify-start">
+    <div class="flex flex-row-reverse items-center justify-between w-full md:flex-row md:space-x-3 md:justify-start">
         <div>
             <div class="w-6 h-6 rounded-full avatar-wrapper md:w-11 md:h-11 loading-state"></div>
         </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please ensure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge your pull request!
-->

## Summary

https://app.clickup.com/t/khd7rz

The "text" part was there but shrank because the wrapper was not using the whole space.

![image](https://user-images.githubusercontent.com/17262776/119873262-fb6fd600-bee9-11eb-91f2-34078be2ac79.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
