### PR TITLE
fix: homepage stats chart size

### DIFF
--- a/resources/views/livewire/price-stats.blade.php
+++ b/resources/views/livewire/price-stats.blade.php
@@ -37,7 +37,6 @@
         <div
             wire:key="{{ Settings::currency() }}"
             class="ml-6"
-            style="width: 120px; height: 40px;"
             x-data="PriceChart(
                 {{ $historical->values()->toJson() }},
                 {{ $historical->keys()->toJson() }},
@@ -49,8 +48,8 @@
             x-init="init"
             @toggle-dark-mode.window="toggleDarkMode"
         >
-            <div class="block" wire:ignore style="width: 120px; height: 40px;">
-                <canvas x-ref="chart" class="w-full h-full" ></canvas>
+            <div class="block" wire:ignore>
+                <canvas x-ref="chart" class="w-full h-full" width="120" height="40" ></canvas>
             </div>
         </div>
     </div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

This sets the chart dimensions directly on the canvas itself, otherwise it would end up out-of-bounds on retina displays

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
