### PR TITLE
chore: use proper border color and radius on mobile tabs

### DIFF
--- a/resources/views/components/latest-records-tabs.blade.php
+++ b/resources/views/components/latest-records-tabs.blade.php
@@ -25,8 +25,8 @@
 
     <div class="mb-4 md:hidden">
         <x-ark-dropdown
-            wrapper-class="relative w-full p-2 border rounded-xl border-theme-primary-100 dark:border-theme-secondary-800"
-            button-class="w-full p-3 font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
+            wrapper-class="relative p-2 w-full rounded-xl border border-theme-primary-100 dark:border-theme-secondary-800"
+            button-class="p-3 w-full font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
             dropdown-classes="left-0 w-full z-20"
             :init-alpine="false"
             dropdown-property="tabsOpen"
@@ -47,7 +47,7 @@
                 </div>
             </x-slot>
 
-            <div class="items-center justify-center block py-3 mt-1">
+            <div class="block justify-center items-center py-3 mt-1">
                 <button wire:key="transactions" type="button" x-on:click="$wire.set('state.selected', 'transactions')" class="dropdown-entry @if($selected === 'transactions') dropdown-entry-selected @endif">
                     @lang('pages.home.latest_transactions')
                 </button>

--- a/resources/views/components/latest-records-tabs.blade.php
+++ b/resources/views/components/latest-records-tabs.blade.php
@@ -25,8 +25,8 @@
 
     <div class="mb-4 md:hidden">
         <x-ark-dropdown
-            wrapper-class="relative p-2 w-full rounded-lg border border-theme-secondary-300 dark:border-theme-secondary-800"
-            button-class="p-3 w-full font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
+            wrapper-class="relative w-full p-2 border rounded-xl border-theme-primary-100 dark:border-theme-secondary-800"
+            button-class="w-full p-3 font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
             dropdown-classes="left-0 w-full z-20"
             :init-alpine="false"
             dropdown-property="tabsOpen"
@@ -47,7 +47,7 @@
                 </div>
             </x-slot>
 
-            <div class="block justify-center items-center py-3 mt-1">
+            <div class="items-center justify-center block py-3 mt-1">
                 <button wire:key="transactions" type="button" x-on:click="$wire.set('state.selected', 'transactions')" class="dropdown-entry @if($selected === 'transactions') dropdown-entry-selected @endif">
                     @lang('pages.home.latest_transactions')
                 </button>

--- a/resources/views/components/transaction-table-filter.blade.php
+++ b/resources/views/components/transaction-table-filter.blade.php
@@ -6,15 +6,15 @@
     }"
 >
     <x-ark-dropdown
-        wrapper-class="relative w-full p-2 border rounded-xl border-theme-primary-100 dark:border-theme-secondary-800 md:w-auto md:p-0 md:border-0"
+        wrapper-class="relative p-2 w-full rounded-xl border border-theme-primary-100 dark:border-theme-secondary-800 md:w-auto md:p-0 md:border-0"
         dropdown-classes="right-0 w-full mt-3 dark:bg-theme-secondary-900 md:w-84"
-        button-class="flex items-center w-full p-3 font-semibold text-left focus:outline-none md:px-8 md:py-0 text-theme-secondary-900 dark:text-theme-secondary-200 md:items-end md:inline"
+        button-class="flex items-center p-3 w-full font-semibold text-left focus:outline-none md:px-8 md:py-0 text-theme-secondary-900 dark:text-theme-secondary-200 md:items-end md:inline"
         dropdown-property="filterOpen"
         :init-alpine="false"
     >
 
         @slot('button')
-            <div class="flex items-center justify-between w-full space-x-2 font-semibold text-theme-secondary-500 md:justify-end md:text-theme-secondary-700">
+            <div class="flex justify-between items-center space-x-2 w-full font-semibold text-theme-secondary-500 md:justify-end md:text-theme-secondary-700">
                 <div>
                     <span class="text-theme-secondary-500 dark:text-theme-secondary-600">@lang('general.transaction.type'):</span>
 
@@ -26,14 +26,14 @@
 
                 <span
                     :class="{ 'rotate-180 md:bg-theme-primary-600 md:text-theme-secondary-100': filterOpen }"
-                    class="flex items-center justify-center w-6 h-6 transition duration-150 ease-in-out rounded-full text-theme-secondary-400 dark:bg-theme-secondary-800 dark:text-theme-secondary-200 md:w-4 md:h-4 md:bg-theme-primary-100 md:text-theme-primary-600"
+                    class="flex justify-center items-center w-6 h-6 rounded-full transition duration-150 ease-in-out text-theme-secondary-400 dark:bg-theme-secondary-800 dark:text-theme-secondary-200 md:w-4 md:h-4 md:bg-theme-primary-100 md:text-theme-primary-600"
                 >
                     <x-ark-icon name="chevron-down" size="xs" class="md:h-3 md:w-2" />
                 </span>
             </div>
         @endslot
 
-        <div class="items-center justify-center block h-64 py-3 overflow-y-scroll dropdown-scrolling md:h-72">
+        <div class="block overflow-y-scroll justify-center items-center py-3 h-64 dropdown-scrolling md:h-72">
             @foreach([
                 'all',
                 'transfer',

--- a/resources/views/components/transaction-table-filter.blade.php
+++ b/resources/views/components/transaction-table-filter.blade.php
@@ -6,15 +6,15 @@
     }"
 >
     <x-ark-dropdown
-        wrapper-class="relative p-2 w-full rounded-lg border border-theme-secondary-300 dark:border-theme-secondary-800 md:w-auto md:p-0 md:border-0"
+        wrapper-class="relative w-full p-2 border rounded-xl border-theme-primary-100 dark:border-theme-secondary-800 md:w-auto md:p-0 md:border-0"
         dropdown-classes="right-0 w-full mt-3 dark:bg-theme-secondary-900 md:w-84"
-        button-class="flex items-center p-3 w-full font-semibold text-left focus:outline-none md:px-8 md:py-0 text-theme-secondary-900 dark:text-theme-secondary-200 md:items-end md:inline"
+        button-class="flex items-center w-full p-3 font-semibold text-left focus:outline-none md:px-8 md:py-0 text-theme-secondary-900 dark:text-theme-secondary-200 md:items-end md:inline"
         dropdown-property="filterOpen"
         :init-alpine="false"
     >
 
         @slot('button')
-            <div class="flex justify-between items-center space-x-2 w-full font-semibold text-theme-secondary-500 md:justify-end md:text-theme-secondary-700">
+            <div class="flex items-center justify-between w-full space-x-2 font-semibold text-theme-secondary-500 md:justify-end md:text-theme-secondary-700">
                 <div>
                     <span class="text-theme-secondary-500 dark:text-theme-secondary-600">@lang('general.transaction.type'):</span>
 
@@ -26,14 +26,14 @@
 
                 <span
                     :class="{ 'rotate-180 md:bg-theme-primary-600 md:text-theme-secondary-100': filterOpen }"
-                    class="flex justify-center items-center w-6 h-6 rounded-full transition duration-150 ease-in-out text-theme-secondary-400 dark:bg-theme-secondary-800 dark:text-theme-secondary-200 md:w-4 md:h-4 md:bg-theme-primary-100 md:text-theme-primary-600"
+                    class="flex items-center justify-center w-6 h-6 transition duration-150 ease-in-out rounded-full text-theme-secondary-400 dark:bg-theme-secondary-800 dark:text-theme-secondary-200 md:w-4 md:h-4 md:bg-theme-primary-100 md:text-theme-primary-600"
                 >
                     <x-ark-icon name="chevron-down" size="xs" class="md:h-3 md:w-2" />
                 </span>
             </div>
         @endslot
 
-        <div class="block overflow-y-scroll justify-center items-center py-3 h-64 dropdown-scrolling md:h-72">
+        <div class="items-center justify-center block h-64 py-3 overflow-y-scroll dropdown-scrolling md:h-72">
             @foreach([
                 'all',
                 'transfer',

--- a/resources/views/livewire/delegate-tabs.blade.php
+++ b/resources/views/livewire/delegate-tabs.blade.php
@@ -1,4 +1,4 @@
-<div class="justify-between hidden md:flex">
+<div class="hidden justify-between md:flex">
     <div class="flex w-9/12 lg:w-10/12 tabs">
         <div
             class="tab-item transition-default"
@@ -52,8 +52,8 @@
 
 <div class="md:hidden">
     <x-ark-dropdown
-        wrapper-class="relative w-full p-2 mb-8 border rounded-xl border-theme-primary-100 dark:border-theme-secondary-800"
-        button-class="w-full p-3 font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
+        wrapper-class="relative p-2 mb-8 w-full rounded-xl border border-theme-primary-100 dark:border-theme-secondary-800"
+        button-class="p-3 w-full font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
         dropdown-classes="left-0 w-full z-20"
         :init-alpine="false"
     >

--- a/resources/views/livewire/delegate-tabs.blade.php
+++ b/resources/views/livewire/delegate-tabs.blade.php
@@ -1,4 +1,4 @@
-<div class="hidden justify-between md:flex">
+<div class="justify-between hidden md:flex">
     <div class="flex w-9/12 lg:w-10/12 tabs">
         <div
             class="tab-item transition-default"
@@ -36,7 +36,7 @@
         </div>
     </div>
 
-    <div class="w-3/12 lg:w-2/12 text-center tabs md:ml-6">
+    <div class="w-3/12 text-center lg:w-2/12 tabs md:ml-6">
         <div
             class="tab-item transition-default"
             :class="{ 'tab-item-current': component === 'monitor' }"
@@ -52,8 +52,8 @@
 
 <div class="md:hidden">
     <x-ark-dropdown
-        wrapper-class="relative p-2 mb-8 w-full rounded-lg border border-theme-secondary-300 dark:border-theme-secondary-800"
-        button-class="p-3 w-full font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
+        wrapper-class="relative w-full p-2 mb-8 border rounded-xl border-theme-primary-100 dark:border-theme-secondary-800"
+        button-class="w-full p-3 font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
         dropdown-classes="left-0 w-full z-20"
         :init-alpine="false"
     >

--- a/resources/views/livewire/wallet-transaction-table.blade.php
+++ b/resources/views/livewire/wallet-transaction-table.blade.php
@@ -31,8 +31,8 @@
 
     <div class="md:hidden">
         <x-ark-dropdown
-            wrapper-class="relative w-full p-2 mb-8 border rounded-xl border-theme-primary-100 dark:border-theme-secondary-800"
-            button-class="w-full p-3 font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
+            wrapper-class="relative p-2 mb-8 w-full rounded-xl border border-theme-primary-100 dark:border-theme-secondary-800"
+            button-class="p-3 w-full font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
             dropdown-classes="left-0 w-full z-20"
             :init-alpine="false"
         >
@@ -56,7 +56,7 @@
                 </div>
             </x-slot>
 
-            <div class="items-center justify-center block py-3 mt-1">
+            <div class="block justify-center items-center py-3 mt-1">
                 <a
                     wire:click="$set('state.direction', 'all');"
                     @click="direction = 'all'"

--- a/resources/views/livewire/wallet-transaction-table.blade.php
+++ b/resources/views/livewire/wallet-transaction-table.blade.php
@@ -31,8 +31,8 @@
 
     <div class="md:hidden">
         <x-ark-dropdown
-            wrapper-class="relative p-2 mb-8 w-full rounded-lg border border-theme-secondary-300 dark:border-theme-secondary-800"
-            button-class="p-3 w-full font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
+            wrapper-class="relative w-full p-2 mb-8 border rounded-xl border-theme-primary-100 dark:border-theme-secondary-800"
+            button-class="w-full p-3 font-semibold text-left text-theme-secondary-900 dark:text-theme-secondary-200"
             dropdown-classes="left-0 w-full z-20"
             :init-alpine="false"
         >
@@ -56,7 +56,7 @@
                 </div>
             </x-slot>
 
-            <div class="block justify-center items-center py-3 mt-1">
+            <div class="items-center justify-center block py-3 mt-1">
                 <a
                     wire:click="$set('state.direction', 'all');"
                     @click="direction = 'all'"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/kkczuv

Now the tabs on mobile have a blue border  with rounded xl, also updated the wallet transactions that use the same menu

![image](https://user-images.githubusercontent.com/17262776/120022410-fbd3a400-bfb1-11eb-92d1-575ce5b15a84.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
