### PR TITLE
fix: transaction listing flaky tests

### DIFF
--- a/tests/Feature/Http/Livewire/Tables/TransactionsTest.php
+++ b/tests/Feature/Http/Livewire/Tables/TransactionsTest.php
@@ -15,7 +15,7 @@ use function Tests\configureExplorerDatabase;
 beforeEach(fn () => configureExplorerDatabase());
 
 it('should list the first page of records', function () {
-    Transaction::factory(30)->create();
+    Transaction::factory(30)->transfer()->create();
 
     $component = Livewire::test(Transactions::class, [
         'transactions' => Transaction::withScope(OrderByTimestampScope::class),

--- a/tests/Feature/Http/Livewire/TransactionTableTest.php
+++ b/tests/Feature/Http/Livewire/TransactionTableTest.php
@@ -21,7 +21,7 @@ use function Tests\configureExplorerDatabase;
 beforeEach(fn () => configureExplorerDatabase());
 
 it('should list the first page of records', function () {
-    Transaction::factory(30)->create();
+    Transaction::factory(30)->transfer()->create();
 
     $component = Livewire::test(TransactionTable::class);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/kv6nxe

The test fails because some type of transaction doesn't show the exact same information that the test is checking. This PR changes to tests to use a fixed transaction type that prevent that problem.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
