### PR TITLE
refactor: address styling and fixed supply row on mobile

### DIFF
--- a/app/Providers/ExplorerServiceProvider.php
+++ b/app/Providers/ExplorerServiceProvider.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
-use ArkEcosystem\Crypto\Configuration\Network as NetworkConfiguration;
 use App\Contracts\Network;
 use App\Services\Blockchain\NetworkFactory;
+use ArkEcosystem\Crypto\Configuration\Network as NetworkConfiguration;
 use Illuminate\Support\ServiceProvider;
 
 final class ExplorerServiceProvider extends ServiceProvider

--- a/resources/views/components/general/identity-delegate.blade.php
+++ b/resources/views/components/general/identity-delegate.blade.php
@@ -3,7 +3,7 @@
         <a href="{{ route('wallet', $model->address()) }}" class="font-semibold link">
             {{ $model->username() }}
         </a>
-        <span class="hidden min-w-0 sm:inline md:hidden lg:inline font-semibold text-theme-secondary-500">
+        <span class="hidden min-w-0 font-semibold sm:inline md:hidden lg:inline text-theme-secondary-500">
             <x-truncate-dynamic>{{ $model->address() }}</x-truncate-dynamic>
         </span>
     </div>

--- a/resources/views/components/general/identity-delegate.blade.php
+++ b/resources/views/components/general/identity-delegate.blade.php
@@ -3,7 +3,7 @@
         <a href="{{ route('wallet', $model->address()) }}" class="font-semibold link">
             {{ $model->username() }}
         </a>
-        <span class="hidden min-w-0 sm:inline md:hidden lg:inline text-theme-secondary-400">
+        <span class="hidden min-w-0 sm:inline md:hidden lg:inline font-semibold text-theme-secondary-500">
             <x-truncate-dynamic>{{ $model->address() }}</x-truncate-dynamic>
         </span>
     </div>

--- a/resources/views/components/tables/mobile/wallets.blade.php
+++ b/resources/views/components/tables/mobile/wallets.blade.php
@@ -7,7 +7,11 @@
 
             <x-tables.rows.mobile.balance :model="$wallet" />
 
-            <x-tables.rows.mobile.vote-percentage :model="$wallet" />
+            @isset($useVoteWeight)
+                <x-tables.rows.mobile.vote-percentage :model="$wallet" />
+            @else
+                <x-tables.rows.mobile.balance-percentage :model="$wallet" />
+            @endif
         </div>
     @endforeach
 </div>

--- a/resources/views/components/tables/rows/desktop/address.blade.php
+++ b/resources/views/components/tables/rows/desktop/address.blade.php
@@ -1,14 +1,14 @@
 <x-general.identity :model="$model" :without-truncate="$withoutTruncate ?? false">
     @if ($model->username())
         <x-slot name="suffix">
-            <span class="hidden ml-1 lg:flex">
+            <span class="hidden ml-1 lg:flex text-theme-secondary-500 font-semibold">
                 <x-truncate-middle>{{ $model->address() }}</x-truncate-middle>
             </span>
         </x-slot>
     @else
         <x-slot name="address">
             <span class="lg:hidden">
-                <x-truncate-middle>{{ $model->address() }}</x-truncate-middle>
+                <x-truncate-middle>{{ $model->address() }}aaaa</x-truncate-middle>
             </span>
             <span class="hidden lg:inline">
                 {{ $model->address() }}

--- a/resources/views/components/tables/rows/desktop/address.blade.php
+++ b/resources/views/components/tables/rows/desktop/address.blade.php
@@ -1,7 +1,7 @@
 <x-general.identity :model="$model" :without-truncate="$withoutTruncate ?? false">
     @if ($model->username())
         <x-slot name="suffix">
-            <span class="hidden ml-1 lg:flex text-theme-secondary-500 font-semibold">
+            <span class="hidden ml-1 font-semibold lg:flex text-theme-secondary-500">
                 <x-truncate-middle>{{ $model->address() }}</x-truncate-middle>
             </span>
         </x-slot>

--- a/resources/views/components/tables/rows/desktop/address.blade.php
+++ b/resources/views/components/tables/rows/desktop/address.blade.php
@@ -8,7 +8,7 @@
     @else
         <x-slot name="address">
             <span class="lg:hidden">
-                <x-truncate-middle>{{ $model->address() }}aaaa</x-truncate-middle>
+                <x-truncate-middle>{{ $model->address() }}</x-truncate-middle>
             </span>
             <span class="hidden lg:inline">
                 {{ $model->address() }}

--- a/resources/views/components/tables/rows/mobile/balance-percentage.blade.php
+++ b/resources/views/components/tables/rows/mobile/balance-percentage.blade.php
@@ -1,5 +1,7 @@
 <div>
     @lang('labels.balance_percentage')
 
+    <span>
     <x-percentage>{{ $model->balancePercentage() }}</x-percentage>
+    </span>
 </div>

--- a/resources/views/components/tables/rows/mobile/balance-percentage.blade.php
+++ b/resources/views/components/tables/rows/mobile/balance-percentage.blade.php
@@ -2,6 +2,6 @@
     @lang('labels.balance_percentage')
 
     <span>
-    <x-percentage>{{ $model->balancePercentage() }}</x-percentage>
+        <x-percentage>{{ $model->balancePercentage() }}</x-percentage>
     </span>
 </div>


### PR DESCRIPTION
## Summary

https://app.clickup.com/t/kxdx81

Also fixed another thing in that PR, going to check now if it was listed on clickup or not, but basically the `Supply` row was borked on mobile, was always displaying any wallet having 100.01% of the supply. Now works properly.

Edit: Updated card on Clickup to reflect what was done here.

## Checklist

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [x] Ready to be merged