### PR TITLE
fix: alignment on delegate table status column

### DIFF
--- a/resources/views/components/tables/headers/desktop/status.blade.php
+++ b/resources/views/components/tables/headers/desktop/status.blade.php
@@ -16,7 +16,7 @@
     :class="$class . ' text-left'"
 >
     @isset ($slot)
-        <div class="inline-flex items-center space-x-2">
+        <div class="inline-flex items-center justify-end w-full space-x-2 md:justify-start">
             <div>@lang($name)</div>
 
             {{ $slot }}

--- a/resources/views/components/tables/headers/desktop/status.blade.php
+++ b/resources/views/components/tables/headers/desktop/status.blade.php
@@ -16,7 +16,7 @@
     :class="$class . ' text-left'"
 >
     @isset ($slot)
-        <div class="inline-flex items-center justify-end w-full space-x-2 md:justify-start">
+        <div class="inline-flex justify-end items-center space-x-2 w-full md:justify-start">
             <div>@lang($name)</div>
 
             {{ $slot }}

--- a/resources/views/components/tables/rows/desktop/round-status-history.blade.php
+++ b/resources/views/components/tables/rows/desktop/round-status-history.blade.php
@@ -1,4 +1,4 @@
-<div class="flex flex-row items-center justify-end w-full space-x-1 round-status-history md:justify-start">
+<div class="flex flex-row justify-end items-center space-x-1 w-full round-status-history md:justify-start">
     @foreach($model->performance() as $performed)
         @if($performed)
             <span class="text-theme-success-500 round-status">

--- a/resources/views/components/tables/rows/desktop/round-status-history.blade.php
+++ b/resources/views/components/tables/rows/desktop/round-status-history.blade.php
@@ -1,4 +1,4 @@
-<div class="flex flex-row items-center space-x-1 round-status-history">
+<div class="flex flex-row items-center justify-end w-full space-x-1 round-status-history md:justify-start">
     @foreach($model->performance() as $performed)
         @if($performed)
             <span class="text-theme-success-500 round-status">

--- a/resources/views/components/tables/rows/desktop/skeletons/status.blade.php
+++ b/resources/views/components/tables/rows/desktop/skeletons/status.blade.php
@@ -12,7 +12,7 @@
     :first-on="$firstOn"
     :last-on="$lastOn"
 >
-    <div class="flex flex-row items-center space-x-2 md:space-x-3">
+    <div class="flex flex-row items-center justify-end w-full space-x-2 md:space-x-3 md:justify-start">
         <div class="w-6 h-6 rounded-full md:w-11 md:h-11 loading-state status-circle"></div>
         <div class="hidden w-6 h-6 rounded-full sm:block md:w-11 md:h-11 loading-state status-circle"></div>
         <div class="hidden w-6 h-6 rounded-full sm:block md:w-11 md:h-11 loading-state status-circle"></div>

--- a/resources/views/components/tables/rows/desktop/skeletons/status.blade.php
+++ b/resources/views/components/tables/rows/desktop/skeletons/status.blade.php
@@ -12,7 +12,7 @@
     :first-on="$firstOn"
     :last-on="$lastOn"
 >
-    <div class="flex flex-row items-center justify-end w-full space-x-2 md:space-x-3 md:justify-start">
+    <div class="flex flex-row justify-end items-center space-x-2 w-full md:space-x-3 md:justify-start">
         <div class="w-6 h-6 rounded-full md:w-11 md:h-11 loading-state status-circle"></div>
         <div class="hidden w-6 h-6 rounded-full sm:block md:w-11 md:h-11 loading-state status-circle"></div>
         <div class="hidden w-6 h-6 rounded-full sm:block md:w-11 md:h-11 loading-state status-circle"></div>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Last comment on https://app.clickup.com/t/kz7n4h

Changes the alignment on small screens for the status column & skeleton

![image](https://user-images.githubusercontent.com/17262776/121208348-9d26e980-c83f-11eb-97a1-c1f790a1d392.png)
![image](https://user-images.githubusercontent.com/17262776/121208387-a44df780-c83f-11eb-9075-f088691abcd8.png)


## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
