### PR TITLE
refactor: calculate marketcap on the fly

### DIFF
--- a/app/Console/Commands/CacheCurrenciesData.php
+++ b/app/Console/Commands/CacheCurrenciesData.php
@@ -39,15 +39,13 @@ final class CacheCurrenciesData extends Command
             $currenciesData = CryptoCompare::getCurrenciesData($source, $currencies);
 
             $currenciesData->each(function ($data, $currency) use ($source, $cache) : void {
-                ['price' => $price, 'priceChange' => $priceChange, 'marketCap' => $marketCap] = $data;
+                ['price' => $price, 'priceChange' => $priceChange] = $data;
                 $cache->setPrice($source, $currency, $price);
                 $cache->setPriceChange($source, $currency, $priceChange);
-                $cache->setMarketCap($source, $currency, $marketCap);
             });
         } catch (ConnectionException $e) {
             $currencies->each(function ($currency) use ($source, $cache) : void {
                 $cache->setPrice($source, $currency, null);
-                $cache->setMarketCap($source, $currency, null);
                 $cache->setPriceChange($source, $currency, null);
             });
         }

--- a/app/Http/Livewire/NetworkStatusBlock.php
+++ b/app/Http/Livewire/NetworkStatusBlock.php
@@ -8,6 +8,7 @@ use App\Actions\CacheNetworkHeight;
 use App\Actions\CacheNetworkSupply;
 use App\Facades\Network;
 use App\Services\Cache\NetworkStatusBlockCache;
+use App\Services\MarketCap;
 use App\Services\NumberFormatter;
 use App\Services\Settings;
 use Illuminate\View\View;
@@ -27,7 +28,7 @@ final class NetworkStatusBlock extends Component
             'height'      => CacheNetworkHeight::execute(),
             'network'     => Network::name(),
             'supply'      => CacheNetworkSupply::execute() / 1e8,
-            'marketCap'   => $this->getMarketCapFormatted(),
+            'marketCap'   => MarketCap::getFormatted(Network::currency(), Settings::currency()),
         ]);
     }
 
@@ -54,29 +55,6 @@ final class NetworkStatusBlock extends Component
         return BetterNumberFormatter::new()
             ->formatWithCurrencyCustom(
                 $price,
-                $currency,
-                NumberFormatter::CRYPTO_DECIMALS
-            );
-    }
-
-    private function getMarketCapFormatted(): ? string
-    {
-        $currency  = Settings::currency();
-        $marketcap = (new NetworkStatusBlockCache())->getMarketCap(Network::currency(), $currency);
-
-        if ($marketcap === null) {
-            return null;
-        }
-
-        if (NumberFormatter::isFiat($currency)) {
-            return BetterNumberFormatter::new()
-                ->withLocale(Settings::locale())
-                ->formatWithCurrencyAccounting($marketcap);
-        }
-
-        return BetterNumberFormatter::new()
-            ->formatWithCurrencyCustom(
-                $marketcap,
                 $currency,
                 NumberFormatter::CRYPTO_DECIMALS
             );

--- a/app/Services/Cache/NetworkStatusBlockCache.php
+++ b/app/Services/Cache/NetworkStatusBlockCache.php
@@ -14,20 +14,6 @@ final class NetworkStatusBlockCache implements Contract
 {
     use ManagesCache;
 
-    public function getMarketCap(string $source, string $target): ?float
-    {
-        $marketCap = $this->get(sprintf('marketcap/%s/%s', $source, $target));
-
-        return $marketCap === null ? null : (float) $marketCap;
-    }
-
-    public function setMarketCap(string $source, string $target, ?float $marketcap): ?float
-    {
-        $this->put(sprintf('marketcap/%s/%s', $source, $target), $marketcap);
-
-        return $marketcap;
-    }
-
     public function getHistoricalHourly(string $source, string $target): ?Collection
     {
         return $this->get(sprintf('historical-hourly/%s/%s', $source, $target));

--- a/app/Services/CryptoCompare.php
+++ b/app/Services/CryptoCompare.php
@@ -59,7 +59,6 @@ final class CryptoCompare
             strtoupper($currency) => [
                     'priceChange' => Arr::get($result, 'RAW.'.$source.'.'.strtoupper($currency).'.CHANGEPCT24HOUR', 0) / 100,
                     'price'       => Arr::get($result, 'RAW.'.$source.'.'.strtoupper($currency).'.PRICE', 0),
-                    'marketCap'   => Arr::get($result, 'RAW.'.$source.'.'.strtoupper($currency).'.MKTCAP', 0),
                 ],
             ]);
     }

--- a/app/Services/MarketCap.php
+++ b/app/Services/MarketCap.php
@@ -6,8 +6,6 @@ namespace App\Services;
 
 use App\Actions\CacheNetworkSupply;
 use App\Services\Cache\NetworkStatusBlockCache;
-use App\Services\NumberFormatter;
-use App\Services\Settings;
 use Konceiver\BetterNumberFormatter\BetterNumberFormatter;
 
 final class MarketCap

--- a/app/Services/MarketCap.php
+++ b/app/Services/MarketCap.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Actions\CacheNetworkSupply;
+use App\Services\Cache\NetworkStatusBlockCache;
+use App\Services\NumberFormatter;
+use App\Services\Settings;
+use Konceiver\BetterNumberFormatter\BetterNumberFormatter;
+
+final class MarketCap
+{
+    public static function get(string $source, string $target): ? float
+    {
+        $price = static::getPrice($source, $target);
+
+        if ($price === null) {
+            return null;
+        }
+
+        return $price * static::getSupply();
+    }
+
+    public static function getFormatted(string $source, string $target): ? string
+    {
+        $marketcap = static::get($source, $target);
+
+        if ($marketcap === null) {
+            return null;
+        }
+
+        if (NumberFormatter::isFiat($target)) {
+            return BetterNumberFormatter::new()
+                ->withLocale(Settings::locale())
+                ->formatWithCurrencyAccounting($marketcap);
+        }
+
+        return BetterNumberFormatter::new()
+            ->formatWithCurrencyCustom(
+                $marketcap,
+                $target,
+                NumberFormatter::CRYPTO_DECIMALS
+            );
+    }
+
+    private static function getSupply(): float
+    {
+        return CacheNetworkSupply::execute() / 1e8;
+    }
+
+    private static function getPrice(string $source, string $target): ? float
+    {
+        return (new NetworkStatusBlockCache())->getPrice($source, $target);
+    }
+}

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -27,7 +27,6 @@ it('should render the page without any errors', function () {
         (new FeeCache())->setMaximum($period, 0);
     }
 
-    (new NetworkStatusBlockCache())->setMarketCap('DARK', 'USD', 40898444.3361);
     (new NetworkStatusBlockCache())->setPrice('DARK', 'USD', 0.2907);
     (new CryptoCompareCache())->setHistoricalHourly('DARK', 'USD', 'Y-m-d H:i:s', 23, fn () => collect([]));
     (new CryptoCompareCache())->setHistoricalHourly('DARK', 'USD', 'Y-m-d H:i:s', 24, fn () => collect([]));

--- a/tests/Feature/Http/Livewire/NetworkStatusBlockTest.php
+++ b/tests/Feature/Http/Livewire/NetworkStatusBlockTest.php
@@ -43,13 +43,12 @@ it('should render with a height, supply and market cap', function () {
     ]);
 
     (new NetworkStatusBlockCache())->setPrice('ARK', 'USD', 1.606);
-    (new NetworkStatusBlockCache())->setMarketCap('ARK', 'USD', 254260570.60);
     (new NetworkStatusBlockCache())->setHistoricalHourly('ARK', 'USD', collect());
 
     Livewire::test(NetworkStatusBlock::class)
         ->assertSee('5,651,290') // Height
         ->assertSee('136,280,982 ARK') // Supply
-        ->assertSee('254,260,570.60') // Market cap
+        ->assertSee('$218,867,257.09') // Market cap
         ->assertSee('1.61'); // Price
 });
 
@@ -71,13 +70,12 @@ it('should render with a height, supply and market cap for BTC', function () {
     ]);
 
     (new NetworkStatusBlockCache())->setPrice('ARK', 'BTC', 0.00003132);
-    (new NetworkStatusBlockCache())->setMarketCap('ARK', 'BTC', 4934.2677444);
     (new NetworkStatusBlockCache())->setHistoricalHourly('ARK', 'BTC', collect());
 
     Livewire::test(NetworkStatusBlock::class)
         ->assertSee('5,651,290') // Height
         ->assertSee('136,280,982 ARK') // Supply
-        ->assertSee('4,934.2677444') // Market cap
+        ->assertSee('4,268.32035624 BTC') // Market cap
         ->assertSee('0.00003132'); // Price
 });
 

--- a/tests/Feature/Http/Livewire/PriceStatsTest.php
+++ b/tests/Feature/Http/Livewire/PriceStatsTest.php
@@ -11,7 +11,6 @@ it('should render the values', function () {
     Config::set('explorer.networks.development.canBeExchanged', true);
 
     (new NetworkStatusBlockCache())->setPrice('DARK', 'USD', 1);
-    (new NetworkStatusBlockCache())->setMarketCap('DARK', 'USD', 1);
     (new NetworkStatusBlockCache())->setHistoricalHourly('DARK', 'USD', collect(['1.898', '1.904', '1.967', '1.941', '2.013', '2.213', '2.414', '2.369', '2.469', '2.374', '2.228', '2.211', '2.266', '2.364', '2.341', '2.269', '1.981', '1.889', '1.275', '1.471', '1.498', '1.518', '1.61', '1.638']));
 
     Livewire::test(PriceStats::class)

--- a/tests/Unit/Console/Commands/CacheCurrenciesDataTest.php
+++ b/tests/Unit/Console/Commands/CacheCurrenciesDataTest.php
@@ -31,13 +31,11 @@ it('should execute the command', function () {
     $cache = new NetworkStatusBlockCache();
 
     expect($cache->getPrice(Network::currency(), 'USD'))->toBeNull();
-    expect($cache->getMarketCap(Network::currency(), 'USD'))->toBeNull();
     expect($cache->getPriceChange(Network::currency(), 'USD'))->toBeNull();
 
     (new CacheCurrenciesData())->handle($cache);
 
     expect($cache->getPrice(Network::currency(), 'USD'))->toBe(1.2219981765);
-    expect($cache->getMarketCap(Network::currency(), 'USD'))->toBe(192865161.6011891);
     expect($cache->getPriceChange(Network::currency(), 'USD'))->toBe(0.14989143413680925);
 });
 
@@ -56,7 +54,6 @@ it('set values to null when cryptocompare is down', function () {
     $cache = new NetworkStatusBlockCache();
 
     $cache->setPrice(Network::currency(), 'USD', 1);
-    $cache->setMarketCap(Network::currency(), 'USD', 1);
     $cache->setPriceChange(Network::currency(), 'USD', 1);
 
     Http::fake([
@@ -68,7 +65,6 @@ it('set values to null when cryptocompare is down', function () {
     (new CacheCurrenciesData())->handle($cache);
 
     expect($cache->getPrice(Network::currency(), 'USD'))->toBeNull();
-    expect($cache->getMarketCap(Network::currency(), 'USD'))->toBeNull();
     expect($cache->getPriceChange(Network::currency(), 'USD'))->toBeNull();
 });
 
@@ -89,12 +85,10 @@ it('should ignore the cache for development network', function () {
     $cache = new NetworkStatusBlockCache();
 
     expect($cache->getPrice(Network::currency(), 'USD'))->toBeNull();
-    expect($cache->getMarketCap(Network::currency(), 'USD'))->toBeNull();
     expect($cache->getPriceChange(Network::currency(), 'USD'))->toBeNull();
 
     (new CacheCurrenciesData())->handle($cache);
 
     expect($cache->getPrice(Network::currency(), 'USD'))->toBeNull();
-    expect($cache->getMarketCap(Network::currency(), 'USD'))->toBeNull();
     expect($cache->getPriceChange(Network::currency(), 'USD'))->toBeNull();
 });

--- a/tests/Unit/Services/CryptoCompareTest.php
+++ b/tests/Unit/Services/CryptoCompareTest.php
@@ -15,7 +15,6 @@ it('should fetch the price data for the given collection', function () {
         'USD' => [
             'priceChange' => 0.14989143413680925,
             'price'       => 1.2219981765,
-            'marketCap'   => 192865161.6011891,
         ],
     ]));
 });

--- a/tests/Unit/Services/MarketCapTest.php
+++ b/tests/Unit/Services/MarketCapTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\MarketCap;
+use App\Services\Cache\NetworkCache;
+use App\Services\Cache\NetworkStatusBlockCache;
+
+it('should calculate the supply', function () {
+    (new NetworkStatusBlockCache())->setPrice('ARK', 'USD', 1.234);
+    (new NetworkCache())->setSupply(fn() => 4.567 * 1e8);
+
+    expect(MarketCap::get('ARK', 'USD'))->toBe(5.635678);
+});
+
+it('should return the supply formatted', function () {
+    (new NetworkStatusBlockCache())->setPrice('ARK', 'USD', 1.234);
+    (new NetworkCache())->setSupply(fn() => 4.567 * 1e8);
+
+    expect(MarketCap::getFormatted('ARK', 'USD'))->toBe('$5.64');
+});
+
+it('should return the null if no price', function () {
+    (new NetworkCache())->setSupply(fn() => 4.567 * 1e8);
+
+    expect(MarketCap::get('ARK', 'USD'))->toBeNull;
+    expect(MarketCap::getFormatted('ARK', 'USD'))->toBeNull;
+});

--- a/tests/Unit/Services/MarketCapTest.php
+++ b/tests/Unit/Services/MarketCapTest.php
@@ -2,26 +2,26 @@
 
 declare(strict_types=1);
 
-use App\Services\MarketCap;
 use App\Services\Cache\NetworkCache;
 use App\Services\Cache\NetworkStatusBlockCache;
+use App\Services\MarketCap;
 
 it('should calculate the supply', function () {
     (new NetworkStatusBlockCache())->setPrice('ARK', 'USD', 1.234);
-    (new NetworkCache())->setSupply(fn() => 4.567 * 1e8);
+    (new NetworkCache())->setSupply(fn () => 4.567 * 1e8);
 
     expect(MarketCap::get('ARK', 'USD'))->toBe(5.635678);
 });
 
 it('should return the supply formatted', function () {
     (new NetworkStatusBlockCache())->setPrice('ARK', 'USD', 1.234);
-    (new NetworkCache())->setSupply(fn() => 4.567 * 1e8);
+    (new NetworkCache())->setSupply(fn () => 4.567 * 1e8);
 
     expect(MarketCap::getFormatted('ARK', 'USD'))->toBe('$5.64');
 });
 
 it('should return the null if no price', function () {
-    (new NetworkCache())->setSupply(fn() => 4.567 * 1e8);
+    (new NetworkCache())->setSupply(fn () => 4.567 * 1e8);
 
     expect(MarketCap::get('ARK', 'USD'))->toBeNull;
     expect(MarketCap::getFormatted('ARK', 'USD'))->toBeNull;


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

- The marketcap is now calculated with price * supply
- Removed references to marketcap caching and updated test

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
