### PR TITLE
fix: wallet transaction table reset pagination when filtering

### DIFF
--- a/app/Http/Livewire/WalletTransactionTable.php
+++ b/app/Http/Livewire/WalletTransactionTable.php
@@ -42,7 +42,7 @@ final class WalletTransactionTable extends Component
         $this->state['direction'] = $value;
     }
 
-    public function updatedStateType(): void
+    public function updatedState(): void
     {
         $this->gotoPage(1);
     }

--- a/tests/Feature/Http/Livewire/WalletTransactionTableTest.php
+++ b/tests/Feature/Http/Livewire/WalletTransactionTableTest.php
@@ -192,6 +192,22 @@ it('should apply filters', function () {
     }
 });
 
+it('should reset the pagination when state changes', function () {
+    $component = Livewire::test(WalletTransactionTable::class, [$this->subject->address, false, $this->subject->public_key]);
+
+    $component->set('page', 3);
+    $component->assertSet('page', 3);
+
+    $component->set('state.type', 'vote');
+    $component->assertSet('page', 1);
+
+    $component->set('page', 3);
+    $component->assertSet('page', 3);
+
+    $component->set('state.direction', 'sent');
+    $component->assertSet('page', 1);
+});
+
 it('should apply filters through an event', function () {
     $block = Block::factory()->create();
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/m9bpv8

now it resets the pagination when a filter is applied or the direction changes

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
