### PR TITLE
refactor: remove md5 hashing from id generation helper

### DIFF
--- a/app/Services/Helpers.php
+++ b/app/Services/Helpers.php
@@ -7,11 +7,11 @@ namespace App\Services;
 final class Helpers
 {
     /**
-     * Blends multiple parameters and creates an unique 10 chars string.
+     * Blends multiple parameters into a single string.
      * Useful for wire:keys.
      */
-    public static function generateHashId(int | bool | string | null ...$params): string
+    public static function generateId(int | bool | string | null ...$params): string
     {
-        return substr(md5(implode('*', $params)), 0, 10);
+        return implode('*', $params);
     }
 }

--- a/tests/Unit/Services/HelpersTest.php
+++ b/tests/Unit/Services/HelpersTest.php
@@ -4,25 +4,25 @@ declare(strict_types=1);
 
 use App\Services\Helpers;
 
-it('it blends different parameters into an unique key', function () {
-    $params = ['an string', true, '', null, 4];
+it('it blends different parameters into an unique string', function () {
+    $params = ['somestring', true, '', null, 4];
 
-    $str = Helpers::generateHashId(...$params);
+    $str = Helpers::generateId(...$params);
 
-    expect($str)->toBe('c5d9cef958');
+    expect($str)->toBe('somestring*1***4');
 
     // Same string second time
-    expect($str)->toBe(Helpers::generateHashId(...$params));
+    expect($str)->toBe(Helpers::generateId(...$params));
 });
 
-it('different parameters create different key', function () {
-    $params1 = ['an string', true, '', null, 4];
-    $params2 = ['an string', true, null, 4];
-    $params3 = ['an string', true, '', null, 5];
+it('different parameters create different string', function () {
+    $params1 = ['some-string', true, '', null, 4];
+    $params2 = ['some-string', true, null, 4];
+    $params3 = ['some-string', true, '', null, 5];
 
-    $str1 = Helpers::generateHashId(...$params1);
-    $str2 = Helpers::generateHashId(...$params2);
-    $str3 = Helpers::generateHashId(...$params3);
+    $str1 = Helpers::generateId(...$params1);
+    $str2 = Helpers::generateId(...$params2);
+    $str3 = Helpers::generateId(...$params3);
 
     expect($str1)->not->toBe($str2);
     expect($str1)->not->toBe($str3);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

Removes the md5 method for better performance  and rename the method to something more accurate since is not a hash anymore.

## Checklist

<!-- Have you done all of these things?  -->

- [ ] Documentation _(if necessary)_
- [ ] Tests _(if necessary)_
- [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
