### PR TITLE
fix: add unique wire:key to delegate monitor rows

### DIFF
--- a/resources/views/components/tables/desktop/delegates/monitor.blade.php
+++ b/resources/views/components/tables/desktop/delegates/monitor.blade.php
@@ -16,14 +16,14 @@
     <tbody>
         @foreach($delegates as $delegate)
             <x-ark-tables.row
-                wire:key="{{ $delegate->publicKey() }}-{{ $round }}"
+                wire:key="{{ Helpers::generateId($delegate->publicKey(), $round, $delegate->status()) }}"
                 :danger="$delegate->keepsMissing()"
                 :warning="$delegate->justMissed()"
             >
                 <x-ark-tables.cell>
                     <x-tables.rows.desktop.slot-id :model="$delegate" />
                 </x-ark-tables.cell>
-                <x-ark-tables.cell wire:key="{{ $delegate->publicKey() }}-username-desktop">
+                <x-ark-tables.cell>
                     <span class="hidden md:inline">
                         <x-tables.rows.desktop.username :model="$delegate->wallet()" />
                     </span>
@@ -34,7 +34,7 @@
                 <x-ark-tables.cell responsive breakpoint="sm">
                     <x-tables.rows.desktop.slot-time :model="$delegate" />
                 </x-ark-tables.cell>
-                <x-ark-tables.cell wire:key="{{ $delegate->publicKey() }}-round-status-{{ $delegate->status() }}-desktop" last-on="md">
+                <x-ark-tables.cell last-on="md">
                     <x-tables.rows.desktop.round-status :model="$delegate" />
                 </x-ark-tables.cell>
                 <x-ark-tables.cell class="text-right" responsive breakpoint="md" >


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/mqa2ve

Add a unique `wire:key` to the rows on the delegate monitor and remove the keys on the cell. That will prevent any issues with broken layouts on the table.

To test keep open the delegate section for a while, go for a coffee, etc when you back should be continued working 

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [x] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
