### PR TITLE
fix: transaction search taking precedence over block search

### DIFF
--- a/app/Http/Livewire/SearchModule.php
+++ b/app/Http/Livewire/SearchModule.php
@@ -62,7 +62,7 @@ final class SearchModule extends Component
             $data['term'] = preg_replace('/(0x[0-9A-Z]+)/', '', $data['term']);
         }
 
-        if ($this->searchWallet($data)) {
+        if ($this->searchBlock($data)) {
             return;
         }
 
@@ -70,7 +70,7 @@ final class SearchModule extends Component
             return;
         }
 
-        if ($this->searchBlock($data)) {
+        if ($this->searchWallet($data)) {
             return;
         }
 

--- a/tests/Feature/Http/Livewire/SearchModuleTest.php
+++ b/tests/Feature/Http/Livewire/SearchModuleTest.php
@@ -13,6 +13,9 @@ beforeEach(fn () => configureExplorerDatabase());
 
 it('should search for a wallet and redirect', function () {
     $wallet = Wallet::factory()->create();
+    Transaction::factory()->create();
+    $block = Block::factory()->create();
+    Transaction::factory()->create(['block_id' => $block->id]);
 
     Livewire::test(SearchModule::class)
         ->set('state.term', $wallet->address)
@@ -22,6 +25,9 @@ it('should search for a wallet and redirect', function () {
 });
 
 it('should search for a transaction and redirect', function () {
+    Transaction::factory()->create();
+    $block = Block::factory()->create();
+    Transaction::factory()->create(['block_id' => $block->id]);
     $transaction = Transaction::factory()->create();
 
     Livewire::test(SearchModule::class)
@@ -32,7 +38,9 @@ it('should search for a transaction and redirect', function () {
 });
 
 it('should search for a block and redirect', function () {
+    Transaction::factory()->create();
     $block = Block::factory()->create();
+    Transaction::factory()->create(['block_id' => $block->id]);
 
     Livewire::test(SearchModule::class)
         ->set('state.term', $block->id)

--- a/tests/Unit/Services/Search/WalletSearchTest.php
+++ b/tests/Unit/Services/Search/WalletSearchTest.php
@@ -45,7 +45,7 @@ it('should search for a wallet by username', function (?string $modifier) {
     $wallet = Wallet::factory(10)->create()[0];
 
     $result = (new WalletSearch())->search([
-        'term' => '',
+        'term'     => '',
         'username' => $modifier ? $modifier($wallet->attributes['delegate']['username']) : $wallet->attributes['delegate']['username'],
     ]);
 

--- a/tests/Unit/Services/Search/WalletSearchTest.php
+++ b/tests/Unit/Services/Search/WalletSearchTest.php
@@ -45,6 +45,7 @@ it('should search for a wallet by username', function (?string $modifier) {
     $wallet = Wallet::factory(10)->create()[0];
 
     $result = (new WalletSearch())->search([
+        'term' => '',
         'username' => $modifier ? $modifier($wallet->attributes['delegate']['username']) : $wallet->attributes['delegate']['username'],
     ]);
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/pdf4ym

This PR fixes a strange behavior: searching for "block ID" opens a transaction page.
This was happening only for blocks with transactions.

## How to test
1. open the explorer homepage
2. click on the search icon in the navigation bar
3. type `0397828b09fff7d41d4a43f1371afdd483764aec1c823b2518a551bfd26d8f28` and click `find it`
4. expect to see the block detail page for the given block

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [x] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
