### PR TITLE
fix: broken ID icons

### DIFF
--- a/resources/views/components/latest-records-tabs.blade.php
+++ b/resources/views/components/latest-records-tabs.blade.php
@@ -33,7 +33,7 @@
         >
             <x-slot name="button">
                 <div class="flex items-center space-x-4">
-                    <div>
+                    <div wire:ignore>
                         <div x-show="tabsOpen !== true">
                             <x-ark-icon name="menu" size="sm" />
                         </div>

--- a/resources/views/components/tables/mobile/blocks.blade.php
+++ b/resources/views/components/tables/mobile/blocks.blade.php
@@ -1,6 +1,6 @@
 <div class="divide-y table-list-mobile">
     @foreach ($blocks as $block)
-        <div class="table-list-mobile-row" wire:key="wire:key="{{ Helpers::generateId('mobile', $block->id(), Settings::currency()) }}">
+        <div class="table-list-mobile-row" wire:key="{{ Helpers::generateId('mobile', $block->id(), Settings::currency()) }}">
             <x-tables.rows.mobile.block-id :model="$block" />
 
             <x-tables.rows.mobile.timestamp :model="$block" />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
Related to https://app.clickup.com/t/pdf3wp

This PR fixes the broken ID icons on "Latest Blocks" table (left image) and the icons overlapping on tab switcher on mobile (right image).
![image](https://user-images.githubusercontent.com/2118799/127129775-011c45a7-1245-4bce-94ad-146a8c943907.png)

## How to test
1. open `homepage`
2. click on "Latest Blocks"
3. leave the tab open for a few minutes
4. expect to see every row with ID icon (not doubled or missing)
-
1. open `homepage` on mobile device
2. click on "Latest Blocks"
3. leave the tab open for a few minutes
4. expect to see only one icon on the left side of "Latest Blocks"

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [x] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
