### PR TITLE
refactor: hide expanded tables setting on mobile

### DIFF
--- a/resources/views/livewire/navbar-settings.blade.php
+++ b/resources/views/livewire/navbar-settings.blade.php
@@ -55,6 +55,7 @@
                 <x-navbar.setting-option
                     :title="trans('forms.settings.table.title')"
                     :subtitle="trans('forms.settings.table.description')"
+                    breakpoint="md"
                 >
                     <x-ark-toggle
                         name="state.compactTables"


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/11m320c

this PR just rollbacks a breakpoint that used to exist for that purpose

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
