### PR TITLE
refactor: update color of the selected currency

### DIFF
--- a/resources/views/livewire/navbar-settings.blade.php
+++ b/resources/views/livewire/navbar-settings.blade.php
@@ -11,7 +11,6 @@
         </span>
     </x-navbar.button>
 
-
     <div
         x-show.transition.origin.top="showSettings"
         class="fixed top-0 right-0 left-0 z-30 px-4 pt-3 mt-20 w-full md:absolute md:left-auto md:p-0 md:mt-24 md:w-120"
@@ -30,13 +29,15 @@
                             wire:model="state.currency"
                             wrapper-class="left-0 mt-3"
                             dropdown-class="right-0 mt-1 origin-top-right"
-                            initial-value="{{ $this->state['currency'] ?? 'USD' }}"
+                            initial-value="{{ Str::lower($this->state['currency'] ?? 'USD') }}"
                             placeholder="{{ $this->state['currency'] ?? 'USD' }}"
-                            button-class="block font-medium text-left bg-transparent text-theme-secondary-900 dark:text-theme-secondary-200"
+                            button-class="block font-medium text-left bg-transparent text-theme-secondary-700 dark:text-theme-secondary-200"
                             :options="collect(config('currencies'))->keys()->mapWithKeys(function ($currency) {
                                 return [$currency => config('currencies.' . $currency)['currency']];
                             })->toArray()"
                         />
+
+
                     </x-navbar.setting-option>
                 @endif
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

The color you see is really the color of the placeholder (that matches the current value) that why it has that off-color, still the color is incorrect, so:
1. Updates the color for gray-700
2. Ensure it selects the current currency so you see the selected option

to test set `EXPLORER_NETWORK_CAN_BE_EXCHANGED=true' so you see the currency selector

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [x] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
