### PR TITLE
fix: delegate broken headers

### DIFF
--- a/resources/views/components/tables/desktop/delegates/active.blade.php
+++ b/resources/views/components/tables/desktop/delegates/active.blade.php
@@ -1,5 +1,5 @@
 <x-ark-tables.table sticky class="w-full">
-    <thead wire:ignore>
+    <thead>
         <tr>
             <x-tables.headers.desktop.text name="general.delegates.rank" />
             <x-tables.headers.desktop.address name="general.delegates.name" />

--- a/resources/views/components/tables/desktop/delegates/monitor.blade.php
+++ b/resources/views/components/tables/desktop/delegates/monitor.blade.php
@@ -1,5 +1,5 @@
 <x-ark-tables.table sticky class="w-full">
-    <thead wire:ignore>
+    <thead>
         <tr>
             <x-tables.headers.desktop.text name="pages.delegates.order" />
             <x-tables.headers.desktop.address name="pages.delegates.name" />

--- a/resources/views/components/tables/desktop/delegates/resigned.blade.php
+++ b/resources/views/components/tables/desktop/delegates/resigned.blade.php
@@ -1,5 +1,5 @@
 <x-ark-tables.table sticky class="w-full">
-    <thead wire:ignore>
+    <thead>
         <tr>
             <x-tables.headers.desktop.id name="general.delegates.id" />
             <x-tables.headers.desktop.address name="general.delegates.name"/>

--- a/resources/views/components/tables/desktop/delegates/standby.blade.php
+++ b/resources/views/components/tables/desktop/delegates/standby.blade.php
@@ -1,5 +1,5 @@
 <x-ark-tables.table sticky class="w-full">
-    <thead wire:ignore>
+    <thead>
         <tr>
             <x-tables.headers.desktop.text name="general.delegates.rank" />
             <x-tables.headers.desktop.address name="general.delegates.name" />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/11m36wa

The issue described on the ticket is because livewire is messing the table headers on the different tabs, you can test it by changing from one tab to another until you see the issue

The problem is related to the wire:ignore attribute that I added [on this PR](https://github.com/ArkEcosystem/explorer.ark.io/pull/896/files) related [to this ticket](https://app.clickup.com/t/qtfc1k)

Once I remove those `wire:ignore` attribute everything works fine and seems that the underlying issue related to the first PR is not failing anymore.

So, to test you need to test focus on both issues:
- the headers messing up from the ticket
- that the icons on the headers don't disappear

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [X] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [x] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
