### PR TITLE
fix: fiat tooltip exchange rate

### DIFF
--- a/app/Services/ExchangeRate.php
+++ b/app/Services/ExchangeRate.php
@@ -12,7 +12,7 @@ final class ExchangeRate
 {
     public static function convert(float $amount, int $timestamp): string
     {
-        $prices       = (new CryptoDataCache())->getPrices(Settings::currency());
+        $prices       = (new CryptoDataCache())->getPrices(Settings::currency().'.week');
         $exchangeRate = Arr::get($prices, Carbon::parse(static::timestamp($timestamp))->format('Y-m-d'), 0);
 
         return NumberFormatter::currency($amount * $exchangeRate, Settings::currency());
@@ -20,11 +20,7 @@ final class ExchangeRate
 
     public static function now(): float
     {
-        return (float) Arr::get(
-            (new CryptoDataCache())->getPrices(Settings::currency()),
-            Carbon::now()->format('Y-m-d'),
-            0
-        );
+        return (float) (new CryptoDataCache())->getPrices(Settings::currency().'.day')->last();
     }
 
     private static function timestamp(int $timestamp): Carbon

--- a/tests/Feature/Http/Livewire/BlockTableTest.php
+++ b/tests/Feature/Http/Livewire/BlockTableTest.php
@@ -33,11 +33,11 @@ it('should list the first page of records', function () {
 it('should update the records fiat tooltip when currency changed', function () {
     Config::set('explorer.networks.development.canBeExchanged', true);
 
-    (new CryptoDataCache())->setPrices('USD', collect([
+    (new CryptoDataCache())->setPrices('USD.week', collect([
         '2020-10-19' => 24210,
     ]));
 
-    (new CryptoDataCache())->setPrices('BTC', collect([
+    (new CryptoDataCache())->setPrices('BTC.week', collect([
         '2020-10-19' => 0.1234567,
     ]));
 

--- a/tests/Feature/Http/Livewire/BlockTransactionsTableTest.php
+++ b/tests/Feature/Http/Livewire/BlockTransactionsTableTest.php
@@ -33,11 +33,11 @@ it('should list the first transactions for the giving block id', function () {
 it('should update the records fiat tooltip when currency changed', function () {
     Config::set('explorer.networks.development.canBeExchanged', true);
 
-    (new CryptoDataCache())->setPrices('USD', collect([
+    (new CryptoDataCache())->setPrices('USD.week', collect([
         '2020-10-19' => 24210,
     ]));
 
-    (new CryptoDataCache())->setPrices('BTC', collect([
+    (new CryptoDataCache())->setPrices('BTC.week', collect([
         '2020-10-19' => 0.1234567,
     ]));
 

--- a/tests/Feature/Http/Livewire/TransactionTableTest.php
+++ b/tests/Feature/Http/Livewire/TransactionTableTest.php
@@ -113,11 +113,11 @@ it('should apply filters through an event', function () {
 it('should update the records fiat tooltip when currency changed', function () {
     Config::set('explorer.networks.development.canBeExchanged', true);
 
-    (new CryptoDataCache())->setPrices('USD', collect([
+    (new CryptoDataCache())->setPrices('USD.week', collect([
         '2020-10-19' => 24210,
     ]));
 
-    (new CryptoDataCache())->setPrices('BTC', collect([
+    (new CryptoDataCache())->setPrices('BTC.week', collect([
         '2020-10-19' => 0.1234567,
     ]));
 

--- a/tests/Feature/Http/Livewire/WalletBalanceTest.php
+++ b/tests/Feature/Http/Livewire/WalletBalanceTest.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Session;
 use Livewire\Livewire;
 
 it('should show the balance of the wallet', function () {
-    (new CryptoDataCache())->setPrices('USD', collect([
+    (new CryptoDataCache())->setPrices('USD.week', collect([
         Carbon::now()->format('Y-m-d') => 10,
     ]));
 
@@ -23,11 +23,11 @@ it('should show the balance of the wallet', function () {
 });
 
 it('updates the balance when currency changes', function () {
-    (new CryptoDataCache())->setPrices('USD', collect([
+    (new CryptoDataCache())->setPrices('USD.week', collect([
         Carbon::now()->format('Y-m-d') => 10,
     ]));
 
-    (new CryptoDataCache())->setPrices('BTC', collect([
+    (new CryptoDataCache())->setPrices('BTC.week', collect([
         Carbon::now()->format('Y-m-d') => 0.1234567,
     ]));
 

--- a/tests/Unit/Services/ExchangeRateTest.php
+++ b/tests/Unit/Services/ExchangeRateTest.php
@@ -5,18 +5,28 @@ declare(strict_types=1);
 use App\Services\Cache\CryptoDataCache;
 use App\Services\ExchangeRate;
 use App\Services\NumberFormatter;
+use App\Services\Timestamp;
 use Carbon\Carbon;
 
 it('should convert with a historical rate', function () {
-    (new CryptoDataCache())->setPrices('USD', collect([]));
-
-    expect(ExchangeRate::convert(1, 0))->toBe(NumberFormatter::currency(0, 'USD'));
-});
-
-it('should convert with the current rate', function () {
-    (new CryptoDataCache())->setPrices('USD', collect([
+    (new CryptoDataCache())->setPrices('USD.week', collect([
+        Carbon::now()->subDays(3)->format('Y-m-d') => 1,
+        Carbon::now()->subDays(2)->format('Y-m-d') => 2,
+        Carbon::now()->subDays(1)->format('Y-m-d') => 3,
         Carbon::now()->format('Y-m-d') => 10,
     ]));
 
-    expect(ExchangeRate::now(1))->toBe(10.0);
+    expect(ExchangeRate::convert(10, Timestamp::now()->subDays(1)->timestamp))
+        ->toBe(NumberFormatter::currency(30, 'USD.week'));
+});
+
+it('should convert with the current rate', function () {
+    (new CryptoDataCache())->setPrices('USD.day', collect([
+        Carbon::now('-3 hours')->format('Y-m-d H:i:s') => 1,
+        Carbon::now('-2 hours')->format('Y-m-d H:i:s') => 2,
+        Carbon::now('-1 hour')->format('Y-m-d H:i:s') => 3,
+        Carbon::now()->format('Y-m-d H:i:s') => 10,
+    ]));
+
+    expect(ExchangeRate::now())->toBe(10.0);
 });

--- a/tests/Unit/Services/ExchangeRateTest.php
+++ b/tests/Unit/Services/ExchangeRateTest.php
@@ -13,7 +13,7 @@ it('should convert with a historical rate', function () {
         Carbon::now()->subDays(3)->format('Y-m-d') => 1,
         Carbon::now()->subDays(2)->format('Y-m-d') => 2,
         Carbon::now()->subDays(1)->format('Y-m-d') => 3,
-        Carbon::now()->format('Y-m-d') => 10,
+        Carbon::now()->format('Y-m-d')             => 10,
     ]));
 
     expect(ExchangeRate::convert(10, Timestamp::now()->subDays(1)->timestamp))
@@ -24,8 +24,8 @@ it('should convert with the current rate', function () {
     (new CryptoDataCache())->setPrices('USD.day', collect([
         Carbon::now('-3 hours')->format('Y-m-d H:i:s') => 1,
         Carbon::now('-2 hours')->format('Y-m-d H:i:s') => 2,
-        Carbon::now('-1 hour')->format('Y-m-d H:i:s') => 3,
-        Carbon::now()->format('Y-m-d H:i:s') => 10,
+        Carbon::now('-1 hour')->format('Y-m-d H:i:s')  => 3,
+        Carbon::now()->format('Y-m-d H:i:s')           => 10,
     ]));
 
     expect(ExchangeRate::now())->toBe(10.0);

--- a/tests/Unit/ViewModels/TransactionViewModelTest.php
+++ b/tests/Unit/ViewModels/TransactionViewModelTest.php
@@ -170,7 +170,7 @@ it('should get the amount in fiat for multi payments excluding payment to the sa
         ],
     ]));
 
-    (new CryptoDataCache())->setPrices('USD', collect([
+    (new CryptoDataCache())->setPrices('USD.week', collect([
         Carbon::parse($this->subject->timestamp())->format('Y-m-d') => 0.2907,
     ]));
 
@@ -268,7 +268,7 @@ it('should get the amount as fiat', function () {
 
     $this->subject = new TransactionViewModel($transaction);
 
-    (new CryptoDataCache())->setPrices('USD', collect([
+    (new CryptoDataCache())->setPrices('USD.week', collect([
         Carbon::parse($this->subject->timestamp())->format('Y-m-d') => 0.2907,
     ]));
 
@@ -304,7 +304,7 @@ it('should get the specific multi payment fiat amount for a wallet recipient', f
 
     $this->subject = new TransactionViewModel($transaction);
 
-    (new CryptoDataCache())->setPrices('USD', collect([
+    (new CryptoDataCache())->setPrices('USD.week', collect([
         Carbon::parse($this->subject->timestamp())->format('Y-m-d') => 0.2907,
     ]));
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/12pgfcx

To test, running `php artisan explorer:cache-prices` should be enough - it's cached for 10 minutes by the looks of it. Make sure the following ENVs are set too:

```
EXPLORER_NETWORK=production
EXPLORER_NETWORK_CAN_BE_EXCHANGED=true
EXPLORER_NETWORK_CURRENCY="ARK"
```

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
