### PR TITLE
fix: reduce currency fetching delay to avoid timeouts

### DIFF
--- a/app/Console/Commands/CacheCurrenciesHistory.php
+++ b/app/Console/Commands/CacheCurrenciesHistory.php
@@ -38,7 +38,7 @@ final class CacheCurrenciesHistory extends Command
                 $delay = null;
             } else {
                 // Spread out requests to avoid ratelimits, 6 per minute currently
-                $delay = now()->addSeconds($index * 10);
+                $delay = now()->addSeconds((int) $index * 10);
             }
 
             CacheCurrenciesHistoryJob::dispatch($source, $currency)->delay($delay);

--- a/app/Console/Commands/CacheCurrenciesHistory.php
+++ b/app/Console/Commands/CacheCurrenciesHistory.php
@@ -34,11 +34,11 @@ final class CacheCurrenciesHistory extends Command
         $currencies = collect(config('currencies'))->pluck('currency');
 
         $currencies->each(function ($currency, $index) use ($source): void {
-            // Cache one currency history per-minute
             if ($this->option('no-delay') === true) {
                 $delay = null;
             } else {
-                $delay = now()->addMinutes($index);
+                // Spread out requests to avoid ratelimits, 6 per minute currently
+                $delay = now()->addSeconds($index * 10);
             }
 
             CacheCurrenciesHistoryJob::dispatch($source, $currency)->delay($delay);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1hwuvtt

Reduces the delay to avoid jobs from being marked as failed due to their long running time. Currently it results in 6 requests per minute, which is far below the 50 requests/minute limit that we have on the coingecko api. Alternative is to increase the job timeout but I don't feel that's necessary and prefer to keep the delays lower so the charts are more in line with one another. With long delays the charts might go out of sync between currencies due to volatility of crypto (15-20 minutes is a long time)

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
