### PR TITLE
fix: reduce padding between address and balance

### DIFF
--- a/resources/views/components/general/entity-header.blade.php
+++ b/resources/views/components/general/entity-header.blade.php
@@ -1,6 +1,6 @@
 <div class="flex flex-col">
     <div class="{{ $padding ?? 'px-8 py-6' }} bg-theme-secondary-900 dark:border-theme-secondary-800 border-theme-secondary-300 @if (isset($bottom)) rounded-t-xl border-t-2 border-l-2 border-r-2 @else rounded-xl border-2  @endif lg:relative">
-        <div class="flex overflow-auto flex-col justify-between space-y-8 lg:flex-row lg:space-y-0">
+        <div class="flex overflow-auto flex-col justify-between space-y-6 lg:flex-row lg:space-y-0">
             <div class="flex overflow-auto md:space-x-4">
                 <div class="hidden items-center md:flex">
                     {!! $logo !!}


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1hwwmv3

This PR reduces the padding between address and balance in wallet page on small and medium screen.

![image](https://user-images.githubusercontent.com/2118799/134173421-b373ad71-ec70-486f-8394-00aa6281b633.png)


## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
