### PR TITLE
fix: statistics page when switching to non-fiat value

### DIFF
--- a/app/Http/Livewire/Stats/Chart.php
+++ b/app/Http/Livewire/Stats/Chart.php
@@ -72,7 +72,7 @@ final class Chart extends Component
     private function mainValueFiat(): string
     {
         $currency = Settings::currency();
-        $price = $this->getPrice($currency);
+        $price    = $this->getPrice($currency);
 
         if (ServiceNumberFormatter::isFiat($currency)) {
             return BetterNumberFormatter::new()

--- a/app/Http/Livewire/Stats/Chart.php
+++ b/app/Http/Livewire/Stats/Chart.php
@@ -71,10 +71,22 @@ final class Chart extends Component
 
     private function mainValueFiat(): string
     {
-        return BetterNumberFormatter::new()
+        $currency = Settings::currency();
+        $price = $this->getPrice($currency);
+
+        if (ServiceNumberFormatter::isFiat($currency)) {
+            return BetterNumberFormatter::new()
                 ->withLocale(Settings::locale())
                 ->withFractionDigits(2)
-                ->formatWithCurrencyAccounting($this->getPrice(Settings::currency()));
+                ->formatWithCurrencyAccounting($price);
+        }
+
+        return BetterNumberFormatter::new()
+                ->formatWithCurrencyCustom(
+                    $price,
+                    $currency,
+                    ServiceNumberFormatter::CRYPTO_DECIMALS
+                );
     }
 
     private function mainValuePercentage(): float

--- a/app/Services/Settings.php
+++ b/app/Services/Settings.php
@@ -36,6 +36,8 @@ final class Settings
 
     public static function locale(): string
     {
+        // Since sometimes the key exists (crypto values) but returns `null`, we need another default value
+        // in the end to handle that case
         return Arr::get(config('currencies'), strtolower(static::currency()).'.locale', 'en_US') ?? 'en_US';
     }
 

--- a/app/Services/Settings.php
+++ b/app/Services/Settings.php
@@ -31,27 +31,27 @@ final class Settings
 
     public static function currency(): string
     {
-        return Str::upper(Arr::get(static::all(), 'currency', 'USD'));
+        return Str::upper(Arr::get(static::all(), 'currency'));
     }
 
     public static function locale(): string
     {
-        return Arr::get(config('currencies'), strtolower(static::currency()).'.locale', 'en_US');
+        return Arr::get(config('currencies'), strtolower(static::currency()).'.locale', 'en_US') ?? 'en_US';
     }
 
     public static function priceChart(): bool
     {
-        return Arr::get(static::all(), 'priceChart', true);
+        return (bool) Arr::get(static::all(), 'priceChart', true);
     }
 
     public static function feeChart(): bool
     {
-        return Arr::get(static::all(), 'feeChart', true);
+        return (bool) Arr::get(static::all(), 'feeChart', true);
     }
 
     public static function darkTheme(): bool
     {
-        return Arr::get(static::all(), 'darkTheme', true);
+        return (bool) Arr::get(static::all(), 'darkTheme', true);
     }
 
     public static function theme(): string
@@ -65,7 +65,7 @@ final class Settings
 
     public static function compactTables(): bool
     {
-        return Arr::get(static::all(), 'compactTables', true);
+        return (bool) Arr::get(static::all(), 'compactTables', true);
     }
 
     public static function usesCharts(): bool

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -7,6 +7,7 @@ namespace Tests;
 use ArkEcosystem\Crypto\Identities\PublicKey;
 use FurqanSiddiqui\BIP39\BIP39;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 
 function fakeKnownWallets(): void
 {
@@ -121,13 +122,13 @@ function fakeKnownWallets(): void
     ]);
 }
 
-function fakeCryptoCompare(bool $setToZero = false): void
+function fakeCryptoCompare(bool $setToZero = false, string $currency = 'USD'): void
 {
     $histohour = 'histohour'.($setToZero ? '-zero' : '');
 
     Http::fake([
         'cryptocompare.com/data/pricemultifull*' => Http::response(json_decode(file_get_contents(base_path('tests/fixtures/cryptocompare/pricemultifull.json')), true), 200),
-        'cryptocompare.com/data/price*'          => Http::response(['USD' => 0.2907, 'BTC' => 0.00002907], 200),
+        'cryptocompare.com/data/price*'          => Http::response([Str::upper($currency) => 0.2907, 'BTC' => 0.00002907], 200),
         'cryptocompare.com/data/histoday*'       => Http::response(json_decode(file_get_contents(base_path('tests/fixtures/cryptocompare/historical.json')), true), 200),
         'cryptocompare.com/data/histohour*'      => Http::response(json_decode(file_get_contents(base_path("tests/fixtures/cryptocompare/{$histohour}.json")), true), 200),
     ]);

--- a/tests/Unit/Services/SettingsTest.php
+++ b/tests/Unit/Services/SettingsTest.php
@@ -40,6 +40,10 @@ it('should have all settings with values from a session', function () {
 
 it('should have a currency setting', function () {
     expect(Settings::currency())->toBe('USD');
+
+    Session::put('settings', json_encode(['currency' => 'BTC']));
+
+    expect(Settings::currency())->toBe('BTC');
 });
 
 it('should have a price chart setting', function () {
@@ -155,4 +159,12 @@ it('should determine if visitor uses compact mode', function () {
     Session::put('settings', json_encode(['compactTables' => true]));
 
     expect(Settings::usesCompactTables())->toBeTrue();
+});
+
+it('should have a locale setting', function () {
+    expect(Settings::locale())->toBe('en_US');
+
+    Session::put('settings', json_encode(['currency' => 'BTC']));
+
+    expect(Settings::locale())->toBe('en_US');
 });


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary
https://app.clickup.com/t/1je5v3m

This PR fixes the statistics page when switching to non-fiat value

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [x] Tests _(if necessary)_
-   [x] Ready to be merged

<!-- Feel free to add additional comments. -->
