### PR TITLE
perf: optimize cache-fees command

### DIFF
--- a/app/Console/Commands/CacheFees.php
+++ b/app/Console/Commands/CacheFees.php
@@ -38,7 +38,7 @@ final class CacheFees extends Command
      */
     public function handle(FeeCache $cache)
     {
-        //$cache->setHistorical(StatsPeriods::ALL, HistoricalAggregateFactory::make(StatsPeriods::ALL)->aggregate());
+        $cache->setHistorical(StatsPeriods::ALL, HistoricalAggregateFactory::make(StatsPeriods::ALL)->aggregate());
 
         collect([
             StatsPeriods::DAY,
@@ -47,9 +47,6 @@ final class CacheFees extends Command
             StatsPeriods::QUARTER,
             StatsPeriods::YEAR,
         ])->each(function ($period) use ($cache): void {
-            $cache->setMinimum($period, MinimumAggregateFactory::make($period)->aggregate());
-            $cache->setAverage($period, AverageAggregateFactory::make($period)->aggregate());
-            $cache->setMaximum($period, MaximumAggregateFactory::make($period)->aggregate());
             $cache->setHistorical($period, HistoricalAggregateFactory::make($period)->aggregate());
         });
 

--- a/app/Console/Commands/CacheFees.php
+++ b/app/Console/Commands/CacheFees.php
@@ -7,8 +7,10 @@ namespace App\Console\Commands;
 use App\Enums\StatsPeriods;
 use App\Services\Cache\FeeCache;
 use App\Services\Forms;
+use App\Services\Transactions\Aggregates\Fees\Average\LastAggregate;
 use App\Services\Transactions\Aggregates\Fees\AverageAggregateFactory;
 use App\Services\Transactions\Aggregates\Fees\HistoricalAggregateFactory;
+use App\Services\Transactions\Aggregates\Fees\LastFeeAggregate;
 use App\Services\Transactions\Aggregates\Fees\MaximumAggregateFactory;
 use App\Services\Transactions\Aggregates\Fees\MinimumAggregateFactory;
 use Illuminate\Console\Command;
@@ -50,10 +52,17 @@ final class CacheFees extends Command
             $cache->setHistorical($period, HistoricalAggregateFactory::make($period)->aggregate());
         });
 
-        // collect(Forms::getTransactionOptions())->except('all')->keys()->each(function ($type) use ($cache): void {
-        //     $cache->setMinimum($type, MinimumAggregateFactory::make(self::LAST_20, $type)->aggregate());
-        //     $cache->setAverage($type, AverageAggregateFactory::make(self::LAST_20, $type)->aggregate());
-        //     $cache->setMaximum($type, MaximumAggregateFactory::make(self::LAST_20, $type)->aggregate());
-        // });
+        collect(Forms::getTransactionOptions())->except('all')->keys()->each(function ($type) use ($cache): void {
+            preg_match('/^[a-z]+(\d+)$/', self::LAST_20, $match);
+
+            $result = (new LastFeeAggregate())
+                ->setLimit((int) $match[1])
+                ->setType($type ?? '')
+                ->aggregate();
+
+            $cache->setMinimum($type, $result['minimum']);
+            $cache->setAverage($type, $result['average']);
+            $cache->setMaximum($type, $result['maximum']);
+        });
     }
 }

--- a/app/Console/Commands/CacheFees.php
+++ b/app/Console/Commands/CacheFees.php
@@ -7,12 +7,8 @@ namespace App\Console\Commands;
 use App\Enums\StatsPeriods;
 use App\Services\Cache\FeeCache;
 use App\Services\Forms;
-use App\Services\Transactions\Aggregates\Fees\Average\LastAggregate;
-use App\Services\Transactions\Aggregates\Fees\AverageAggregateFactory;
 use App\Services\Transactions\Aggregates\Fees\HistoricalAggregateFactory;
 use App\Services\Transactions\Aggregates\Fees\LastFeeAggregate;
-use App\Services\Transactions\Aggregates\Fees\MaximumAggregateFactory;
-use App\Services\Transactions\Aggregates\Fees\MinimumAggregateFactory;
 use Illuminate\Console\Command;
 
 final class CacheFees extends Command

--- a/app/Console/Commands/CacheFees.php
+++ b/app/Console/Commands/CacheFees.php
@@ -38,7 +38,7 @@ final class CacheFees extends Command
      */
     public function handle(FeeCache $cache)
     {
-        $cache->setHistorical(StatsPeriods::ALL, HistoricalAggregateFactory::make(StatsPeriods::ALL)->aggregate());
+        //$cache->setHistorical(StatsPeriods::ALL, HistoricalAggregateFactory::make(StatsPeriods::ALL)->aggregate());
 
         collect([
             StatsPeriods::DAY,
@@ -53,10 +53,10 @@ final class CacheFees extends Command
             $cache->setHistorical($period, HistoricalAggregateFactory::make($period)->aggregate());
         });
 
-        collect(Forms::getTransactionOptions())->except('all')->keys()->each(function ($type) use ($cache): void {
-            $cache->setMinimum($type, MinimumAggregateFactory::make(self::LAST_20, $type)->aggregate());
-            $cache->setAverage($type, AverageAggregateFactory::make(self::LAST_20, $type)->aggregate());
-            $cache->setMaximum($type, MaximumAggregateFactory::make(self::LAST_20, $type)->aggregate());
-        });
+        // collect(Forms::getTransactionOptions())->except('all')->keys()->each(function ($type) use ($cache): void {
+        //     $cache->setMinimum($type, MinimumAggregateFactory::make(self::LAST_20, $type)->aggregate());
+        //     $cache->setAverage($type, AverageAggregateFactory::make(self::LAST_20, $type)->aggregate());
+        //     $cache->setMaximum($type, MaximumAggregateFactory::make(self::LAST_20, $type)->aggregate());
+        // });
     }
 }

--- a/app/Services/Transactions/Aggregates/Fees/AverageAggregateFactory.php
+++ b/app/Services/Transactions/Aggregates/Fees/AverageAggregateFactory.php
@@ -40,13 +40,13 @@ final class AverageAggregateFactory
             return new YearAggregate();
         }
 
-        if (Str::of($period)->contains('last')) {
-            preg_match('/^[a-z]+(\d+)$/', $period, $match);
+        // if (Str::of($period)->contains('last')) {
+        //     preg_match('/^[a-z]+(\d+)$/', $period, $match);
 
-            return (new LastAggregate())
-                ->setLimit((int) $match[1])
-                ->setType($type ?? '');
-        }
+        //     return (new LastAggregate())
+        //         ->setLimit((int) $match[1])
+        //         ->setType($type ?? '');
+        // }
 
         throw new InvalidArgumentException('Invalid aggregate period.');
     }

--- a/app/Services/Transactions/Aggregates/Fees/Historical/AllAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/Historical/AllAggregate.php
@@ -18,11 +18,16 @@ final class AllAggregate
 
     public function aggregate(): Collection
     {
+        $select = [
+            'SUM(fee) as fee',
+            sprintf("to_char(to_timestamp(%d+timestamp) AT TIME ZONE 'UTC', '%s') as formatted_date", Network::epoch()->timestamp, 'YYYY-MM'),
+        ];
+
         return Transaction::query()
-            ->select(DB::raw('SUM(fee) as fee, to_char(to_timestamp(timestamp+'.Network::epoch()->timestamp."), 'YYYY-MM') as month"))
-            ->groupBy('month')
-            ->orderBy('month')
-            ->pluck('fee', 'month')
+            ->select(DB::raw(implode(', ', $select)))
+            ->orderBy('formatted_date')
+            ->groupBy('formatted_date')
+            ->pluck('fee', 'formatted_date')
             ->mapWithKeys(fn ($fee, $month) => [$month => $fee->toFloat()]);
     }
 }

--- a/app/Services/Transactions/Aggregates/Fees/Historical/DayAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/Historical/DayAggregate.php
@@ -17,7 +17,7 @@ final class DayAggregate
     public function aggregate(): Collection
     {
         return $this->mergeWithPlaceholders(
-            (new RangeAggregate())->aggregate(Carbon::now()->subDay()->addHour(), Carbon::now(), 'H'),
+            (new RangeAggregate())->aggregate(Carbon::now()->subDay()->addHour(), Carbon::now(), 'HH24'),
             $this->placeholders((int) Carbon::now()->subDay()->addHour()->timestamp, (int) Carbon::now()->timestamp, 3600, 'H')->take(24)
         );
     }

--- a/app/Services/Transactions/Aggregates/Fees/Historical/MonthAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/Historical/MonthAggregate.php
@@ -17,7 +17,7 @@ final class MonthAggregate
     public function aggregate(): Collection
     {
         return $this->mergeWithPlaceholders(
-            (new RangeAggregate())->aggregate(Carbon::now()->subDays(29), Carbon::now()->addDay(), 'd.m'),
+            (new RangeAggregate())->aggregate(Carbon::now()->subDays(29), Carbon::now()->addDay(), 'DD.MM'),
             $this->placeholders((int) Carbon::now()->subDays(29)->timestamp, (int) Carbon::now()->addDay()->timestamp, 86400, 'd.m')->take(30)
         );
     }

--- a/app/Services/Transactions/Aggregates/Fees/Historical/QuarterAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/Historical/QuarterAggregate.php
@@ -17,7 +17,7 @@ final class QuarterAggregate
     public function aggregate(): Collection
     {
         return $this->mergeWithPlaceholders(
-            (new RangeAggregate())->aggregate(Carbon::now()->subDays(89), Carbon::now()->addDay(), 'M'),
+            (new RangeAggregate())->aggregate(Carbon::now()->subDays(89), Carbon::now()->addDay(), 'Mon'),
             $this->placeholders((int) Carbon::now()->subDays(89)->timestamp, (int) Carbon::now()->addDay()->timestamp, 86400, 'M')->reverse()->take(3)->reverse()
         );
     }

--- a/app/Services/Transactions/Aggregates/Fees/Historical/RangeAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/Historical/RangeAggregate.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Services\Transactions\Aggregates\Fees\Historical;
 
+use App\Facades\Network;
 use App\Services\Timestamp;
 use App\Services\Transactions\Aggregates\Concerns\HasQueries;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 final class RangeAggregate
 {
@@ -15,12 +17,17 @@ final class RangeAggregate
 
     public function aggregate(Carbon $start, Carbon $end, string $format): Collection
     {
+        $select = [
+            'SUM(fee) as fee',
+            sprintf("to_char(to_timestamp(%d+timestamp) AT TIME ZONE 'UTC', '%s') as formatted_date", Network::epoch()->timestamp, $format),
+        ];
+
         return $this
             ->dateRangeQuery($start, $end)
-            ->orderBy('timestamp')
-            ->cursor()
-            ->groupBy(fn ($date) => Timestamp::fromGenesis($date->timestamp)->format($format))
-            ->mapWithKeys(fn ($transactions, $day) => [$day => $transactions->sumBigNumber('fee')->toNumber() / 1e8])
-            ->collect();
+            ->select(DB::raw(implode(', ', $select)))
+            ->orderBy('formatted_date')
+            ->groupBy('formatted_date')
+            ->pluck('fee', 'formatted_date')
+            ->mapWithKeys(fn ($fee, $month) => [$month => $fee->toFloat()]);
     }
 }

--- a/app/Services/Transactions/Aggregates/Fees/Historical/RangeAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/Historical/RangeAggregate.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Services\Transactions\Aggregates\Fees\Historical;
 
 use App\Facades\Network;
-use App\Services\Timestamp;
 use App\Services\Transactions\Aggregates\Concerns\HasQueries;
 use Carbon\Carbon;
 use Illuminate\Support\Collection;

--- a/app/Services/Transactions/Aggregates/Fees/Historical/RangeAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/Historical/RangeAggregate.php
@@ -27,6 +27,6 @@ final class RangeAggregate
             ->orderBy('formatted_date')
             ->groupBy('formatted_date')
             ->pluck('fee', 'formatted_date')
-            ->mapWithKeys(fn ($fee, $month) => [$month => $fee->toFloat()]);
+            ->mapWithKeys(fn ($fee, $date) => [$date => $fee->toFloat()]);
     }
 }

--- a/app/Services/Transactions/Aggregates/Fees/Historical/WeekAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/Historical/WeekAggregate.php
@@ -17,7 +17,7 @@ final class WeekAggregate
     public function aggregate(): Collection
     {
         return $this->mergeWithPlaceholders(
-            (new RangeAggregate())->aggregate(Carbon::now()->subDays(6), Carbon::now()->addDay(), 'd.m'),
+            (new RangeAggregate())->aggregate(Carbon::now()->subDays(6), Carbon::now()->addDay(), 'DD.MM'),
             $this->placeholders((int) Carbon::now()->subDays(6)->timestamp, (int) Carbon::now()->addDay()->timestamp, 86400, 'd.m')->take(7)
         );
     }

--- a/app/Services/Transactions/Aggregates/Fees/Historical/YearAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/Historical/YearAggregate.php
@@ -17,7 +17,7 @@ final class YearAggregate
     public function aggregate(): Collection
     {
         return $this->mergeWithPlaceholders(
-            (new RangeAggregate())->aggregate(Carbon::now()->subDays(365)->addMonth(), Carbon::now()->addMonth(), 'M'),
+            (new RangeAggregate())->aggregate(Carbon::now()->subDays(365)->addMonth(), Carbon::now()->addMonth(), 'Mon'),
             $this->placeholders((int) Carbon::now()->subDays(365)->addMonth()->timestamp, (int) Carbon::now()->addMonth()->timestamp, 86400, 'M')->take(365)
         );
     }

--- a/app/Services/Transactions/Aggregates/Fees/LastFeeAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/LastFeeAggregate.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace App\Services\Transactions\Aggregates\Fees;
 
 use App\Models\Transaction;
-use App\Services\BigNumber;
 use App\Services\Transactions\Aggregates\Concerns\HasQueries;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 final class LastFeeAggregate
 {

--- a/app/Services/Transactions/Aggregates/Fees/LastFeeAggregate.php
+++ b/app/Services/Transactions/Aggregates/Fees/LastFeeAggregate.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Transactions\Aggregates\Fees;
+
+use App\Models\Transaction;
+use App\Services\BigNumber;
+use App\Services\Transactions\Aggregates\Concerns\HasQueries;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class LastFeeAggregate
+{
+    use HasQueries;
+
+    private string $type;
+
+    private int $limit = 20;
+
+    public function setType(string $type): self
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    public function setLimit(int $limit): self
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function aggregate(): array
+    {
+        $scope = $this->getScopeByType($this->type);
+
+        $fees = Transaction::query()
+            ->select('fee')
+            ->withScope($scope)
+            ->orderByDesc('timestamp')
+            ->limit($this->limit)
+            ->pluck('fee')
+            ->map(fn ($fee) => $fee->toFloat());
+
+        return [
+            'minimum' => $fees->min() ?? 0,
+            'average' => $fees->avg() ?? 0,
+            'maximum' => $fees->max() ?? 0,
+        ];
+    }
+}

--- a/app/Services/Transactions/Aggregates/Fees/MaximumAggregateFactory.php
+++ b/app/Services/Transactions/Aggregates/Fees/MaximumAggregateFactory.php
@@ -40,13 +40,13 @@ final class MaximumAggregateFactory
             return new YearAggregate();
         }
 
-        if (Str::of($period)->contains('last')) {
-            preg_match('/^[a-z]+(\d+)$/', $period, $match);
+        // if (Str::of($period)->contains('last')) {
+        //     preg_match('/^[a-z]+(\d+)$/', $period, $match);
 
-            return (new LastAggregate())
-                ->setLimit((int) $match[1])
-                ->setType($type ?? '');
-        }
+        //     return (new LastAggregate())
+        //         ->setLimit((int) $match[1])
+        //         ->setType($type ?? '');
+        // }
 
         throw new InvalidArgumentException('Invalid aggregate period.');
     }

--- a/app/Services/Transactions/Aggregates/Fees/MinimumAggregateFactory.php
+++ b/app/Services/Transactions/Aggregates/Fees/MinimumAggregateFactory.php
@@ -40,13 +40,13 @@ final class MinimumAggregateFactory
             return new YearAggregate();
         }
 
-        if (Str::of($period)->contains('last')) {
-            preg_match('/^[a-z]+(\d+)$/', $period, $match);
+        // if (Str::of($period)->contains('last')) {
+        //     preg_match('/^[a-z]+(\d+)$/', $period, $match);
 
-            return (new LastAggregate())
-                ->setLimit((int) $match[1])
-                ->setType($type ?? '');
-        }
+        //     return (new LastAggregate())
+        //         ->setLimit((int) $match[1])
+        //         ->setType($type ?? '');
+        // }
 
         throw new InvalidArgumentException('Invalid aggregate period.');
     }

--- a/tests/Unit/Services/Transactions/Aggregates/Fees/Historical/RangeAggregateTest.php
+++ b/tests/Unit/Services/Transactions/Aggregates/Fees/Historical/RangeAggregateTest.php
@@ -23,7 +23,7 @@ it('should aggregate the fees for the given range', function () {
     $result = (new RangeAggregate())->aggregate(
         Timestamp::fromGenesis($start->last()->timestamp)->startOfDay(),
         Timestamp::fromGenesis($end->last()->timestamp)->endOfDay(),
-        'Y-m-d'
+        'YYYY-MM-DD'
     );
 
     expect($result)->toBeInstanceOf(Collection::class);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1je17f5

This optimizes the `cache-fees` command in a similar fashion to #932 . It also removes obsolete min/avg/max aggregates for historic fees and changes the min/avg/max transaction values to use a single query

The fee aggregate methods may be obsolete now, will add a card to double check that later

Brings down execution time for the `explorer:cache-fees` command from `1m15s` to `8s` on my machine :hide:

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
