### PR TITLE
fix: `scrollToQuery` incorrect targets

### DIFF
--- a/resources/views/components/tables/transactions.blade.php
+++ b/resources/views/components/tables/transactions.blade.php
@@ -7,7 +7,7 @@
         <x-general.pagination :results="$transactions" class="mt-8" />
 
         <script>
-            window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#block-list')));
+            window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#transaction-list')));
         </script>
     </x-skeletons.transactions>
 </div>

--- a/resources/views/components/tables/wallets.blade.php
+++ b/resources/views/components/tables/wallets.blade.php
@@ -7,7 +7,7 @@
         <x-general.pagination :results="$wallets" class="mt-8" />
 
         <script>
-            window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#block-list')));
+            window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#wallet-list')));
         </script>
     </x-skeletons.wallets>
 </div>

--- a/resources/views/livewire/delegate-table.blade.php
+++ b/resources/views/livewire/delegate-table.blade.php
@@ -50,6 +50,6 @@
     @endif
 
     <script>
-        window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#transaction-list')));
+        window.addEventListener('livewire:load', () => window.livewire.on('pageChanged', () => scrollToQuery('#delegate-list')));
     </script>
 </div>

--- a/resources/views/livewire/search-page.blade.php
+++ b/resources/views/livewire/search-page.blade.php
@@ -1,6 +1,6 @@
 <div>
     <div class="dark:bg-black bg-theme-secondary-100">
-        <div class="w-full p-8 content-container-full-width">
+        <div class="p-8 w-full content-container-full-width">
             <livewire:search-module :type="$state['type']" />
         </div>
     </div>

--- a/resources/views/livewire/search-page.blade.php
+++ b/resources/views/livewire/search-page.blade.php
@@ -1,11 +1,11 @@
 <div>
     <div class="dark:bg-black bg-theme-secondary-100">
-        <div class="p-8 w-full content-container-full-width">
+        <div class="w-full p-8 content-container-full-width">
             <livewire:search-module :type="$state['type']" />
         </div>
     </div>
 
-    <x-ark-container>
+    <x-ark-container id="results-list">
         <h1 class="header-2">@lang('pages.search_results.title')</h1>
 
         @if($results && $results->count())


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/1hk1up9

Fixes some incorrect references used on the `scrollToQuery` after page changes on livewire 

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
