### PR TITLE
refactor: pollTransactions to be unnecessary called multiple times

### DIFF
--- a/resources/views/livewire/latest-records.blade.php
+++ b/resources/views/livewire/latest-records.blade.php
@@ -22,7 +22,7 @@
                     <x-tables.mobile.blocks :blocks="$blocks" />
 
                     @if(count($blocks) === 15)
-                        <a href="{{ route('blocks', ['page' => 2]) }}" class="w-full mt-4 button-secondary">@lang('actions.view_all')</a>
+                        <a href="{{ route('blocks', ['page' => 2]) }}" class="mt-4 w-full button-secondary">@lang('actions.view_all')</a>
                     @endif
                 </div>
             @endif
@@ -48,7 +48,7 @@
                     <x-tables.mobile.transactions :transactions="$transactions" />
 
                     @if(count($transactions) === 15)
-                        <a href="{{ route('transactions', ['page' => 2, 'state[type]' => $state['type']]) }}" class="w-full mt-4 button-secondary">@lang('actions.view_all')</a>
+                        <a href="{{ route('transactions', ['page' => 2, 'state[type]' => $state['type']]) }}" class="mt-4 w-full button-secondary">@lang('actions.view_all')</a>
                     @endif
                 </div>
             @endif

--- a/resources/views/livewire/latest-records.blade.php
+++ b/resources/views/livewire/latest-records.blade.php
@@ -22,7 +22,7 @@
                     <x-tables.mobile.blocks :blocks="$blocks" />
 
                     @if(count($blocks) === 15)
-                        <a href="{{ route('blocks', ['page' => 2]) }}" class="mt-4 w-full button-secondary">@lang('actions.view_all')</a>
+                        <a href="{{ route('blocks', ['page' => 2]) }}" class="w-full mt-4 button-secondary">@lang('actions.view_all')</a>
                     @endif
                 </div>
             @endif
@@ -35,7 +35,7 @@
                         <x-general.no-results :text="trans('pages.home.no_transaction_results', [trans('forms.search.transaction_types.'.$state['type'])])" />
                     </div>
                 @else
-                    <div wire:poll="pollTransactions" wire:key="poll_transactions_skeleton">
+                    <div wire:init="pollTransactions" wire:key="poll_transactions_skeleton">
                         <x-tables.desktop.skeleton.transactions />
 
                         <x-tables.mobile.skeleton.transactions />
@@ -48,7 +48,7 @@
                     <x-tables.mobile.transactions :transactions="$transactions" />
 
                     @if(count($transactions) === 15)
-                        <a href="{{ route('transactions', ['page' => 2, 'state[type]' => $state['type']]) }}" class="mt-4 w-full button-secondary">@lang('actions.view_all')</a>
+                        <a href="{{ route('transactions', ['page' => 2, 'state[type]' => $state['type']]) }}" class="w-full mt-4 button-secondary">@lang('actions.view_all')</a>
                     @endif
                 </div>
             @endif


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed, and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge your pull request!
-->

## Summary

https://app.clickup.com/t/1jfveqz

Replaces the `wire:poll="pollTransactions"` for `wire:init="pollTransactions"` on the skeleton which ensures the `pollTransactions` method is only called once until transactions are loaded

To test:

See the network console, the request to`/latest-records` should be called once until transactions are loaded, after that should be called every `8s`

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design, and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [x] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
