### PR TITLE
refactor: add `host.docker.internal` host to the docker container

### DIFF
--- a/docker/docker-compose-build.yml
+++ b/docker/docker-compose-build.yml
@@ -15,6 +15,8 @@ services:
     volumes:
       - explorer:/var/www/explorer
     tty: true
+    extra_hosts:
+      host.docker.internal: host-gateway
 networks:
   explorer:
 volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     volumes:
       - explorer:/var/www/explorer
     tty: true
+    extra_hosts:
+      host.docker.internal: host-gateway
 networks:
   explorer:
 volumes:


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

In a Docker deployment, Explorer is utilizing a local PostgreSQL database (running on the host) and Docker container running the Explorer needs to know what is the IP address of the host machine. Adding `host.docker.internal` will automatically pass the IP of the host to the container and you won't need to find out and hardcode the host IP in the .env file to connect to the database, but rather use `EXPLORER_DB_HOST=host.docker.internal`.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
