### PR TITLE
fix: switch filter label messing

### DIFF
--- a/resources/views/livewire/wallet-transaction-table.blade.php
+++ b/resources/views/livewire/wallet-transaction-table.blade.php
@@ -37,7 +37,7 @@
             :init-alpine="false"
         >
             <x-slot name="button">
-                <div class="flex items-center space-x-4">
+                <div class="flex items-center space-x-4" wire:ignore>
                     <div>
                         <div x-show="dropdownOpen !== true">
                             <x-ark-icon name="menu" size="sm" />


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/200ytem

Adds a wire:ignore attribute to prevent the alpine selection from being cleared

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [x] I checked my UI changes against the design and there are no notable differences
-   [x] I checked my UI changes for any responsiveness issues
-   [x] I checked my UI changes in light AND dark mode
-   [x] I checked my (code) changes for obvious issues, debug statements and commented code
-   [x] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
