### PR TITLE
fix: transaction filter direction

### DIFF
--- a/resources/views/livewire/wallet-transaction-table.blade.php
+++ b/resources/views/livewire/wallet-transaction-table.blade.php
@@ -10,14 +10,14 @@
             <span>@lang('pages.wallet.all_transactions')</span>
         </x-tabs.tab>
 
-        <x-tabs.tab name="transaction.received">
+        <x-tabs.tab name="received">
             <span>@lang('pages.wallet.received_transactions')</span>
 
             <span class="info-badge">{{ $countReceived }}</span>
         </x-tabs.tab>
 
         @unless($state['isCold'])
-            <x-tabs.tab name="transaction.sent">
+            <x-tabs.tab name="sent">
                 <span>@lang('pages.wallet.sent_transactions', [$countSent])</span>
 
                 <span class="info-badge">{{ $countSent }}</span>


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/28z00fp

This PR fixes the bug where both incoming and outgoing transactions in the Wallet page would display all transactions.

Since we're setting and checking the `$state['direction']` property to be `sent` or `received` to know what to filter on, these values need to set properly ([ref](https://github.com/ArkEcosystem/explorer/blob/develop/resources/views/livewire/wallet-transaction-table.blade.php#L108-L109)). `<x-tabs.tab />` components receive the `transaction.sent` and `transaction.received` which is then bound to `$state['direction']` ([ref](https://github.com/ArkEcosystem/explorer/blob/develop/resources/views/livewire/wallet-transaction-table.blade.php#L6)). Because of that, we're never filtering incoming/outgoing and always displaying "All" transactions.

As you can see [here](https://github.com/ArkEcosystem/explorer/blob/develop/resources/views/livewire/wallet-transaction-table.blade.php#L69), mobile dropdown properly sets the data therefore this isn't an issue in mobile.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
