### PR TITLE
fix: searching for wallet names containing whitespace

### DIFF
--- a/app/Services/Search/Traits/ValidatesTerm.php
+++ b/app/Services/Search/Traits/ValidatesTerm.php
@@ -36,7 +36,11 @@ trait ValidatesTerm
      */
     private function couldBeUsername(string $term): bool
     {
-        $regex = '/^[a-zA-Z0-9!@$&_. ]+$/';
+        // "Known wallets" are not related to anything on-chain, they are set by ARK team and can be seen here: https://github.com/ArkEcosystem/common/tree/master/mainnet
+        // They are not related to delegate usernames that are registered on-chain, meaning that they can be anything.
+        // Therefore 30 character restriction is not something that's actively enforced for those names
+
+        $regex = '/^[a-zA-Z0-9!@$&_.()\[\] ]+$/';
 
         return strlen($term) >= 1
             && strlen($term) <= 30

--- a/app/Services/Search/Traits/ValidatesTerm.php
+++ b/app/Services/Search/Traits/ValidatesTerm.php
@@ -36,7 +36,7 @@ trait ValidatesTerm
      */
     private function couldBeUsername(string $term): bool
     {
-        $regex = '/^[a-zA-Z0-9!@$&_.]+$/';
+        $regex = '/^[a-zA-Z0-9!@$&_. ]+$/';
 
         return strlen($term) >= 1
             && strlen($term) <= 20

--- a/app/Services/Search/Traits/ValidatesTerm.php
+++ b/app/Services/Search/Traits/ValidatesTerm.php
@@ -39,7 +39,7 @@ trait ValidatesTerm
         $regex = '/^[a-zA-Z0-9!@$&_. ]+$/';
 
         return strlen($term) >= 1
-            && strlen($term) <= 20
+            && strlen($term) <= 30
             && preg_match($regex, $term, $matches) > 0;
     }
 

--- a/tests/Unit/Repositories/WalletRepositoryTest.php
+++ b/tests/Unit/Repositories/WalletRepositoryTest.php
@@ -48,3 +48,15 @@ it('should find a wallet by username', function () {
 
     expect($this->subject->findByUsername($wallet->attributes['delegate']['username']))->toBeInstanceOf(Wallet::class);
 });
+
+it('should find a wallet by username containing a whitespace', function () {
+    $wallet = Wallet::factory()->create();
+    $delegate = $wallet->attributes['delegate'];
+    $delegate['username'] = 'something with a whitespace';
+
+    $wallet->update([
+        'attributes' => array_merge($wallet->attributes, ['delegate' => $delegate]),
+    ]);
+
+    expect($this->subject->findByUsername($wallet->attributes['delegate']['username']))->toBeInstanceOf(Wallet::class);
+});

--- a/tests/Unit/Repositories/WalletRepositoryTest.php
+++ b/tests/Unit/Repositories/WalletRepositoryTest.php
@@ -50,8 +50,8 @@ it('should find a wallet by username', function () {
 });
 
 it('should find a wallet by username containing a whitespace', function () {
-    $wallet = Wallet::factory()->create();
-    $delegate = $wallet->attributes['delegate'];
+    $wallet               = Wallet::factory()->create();
+    $delegate             = $wallet->attributes['delegate'];
     $delegate['username'] = 'something with a whitespace';
 
     $wallet->update([

--- a/tests/Unit/Services/Search/BlockSearchTest.php
+++ b/tests/Unit/Services/Search/BlockSearchTest.php
@@ -269,3 +269,23 @@ it('should search for blocks by generator with a username', function (?string $m
 
     expect($result->get())->toHaveCount(1);
 })->with([null, 'strtolower', 'strtoupper']);
+
+it('should search for blocks by generator with a username containing a whitespace', function (?string $modifier) {
+    Block::factory(10)->create();
+
+    $block = Block::factory()->create([
+        'generator_public_key' => Wallet::factory()->create([
+            'attributes' => [
+                'delegate' => [
+                    'username' => 'something longer than 20 char',
+                ],
+            ],
+        ])->public_key,
+    ]);
+
+    $result = (new BlockSearch())->search([
+        'term' => $modifier ? $modifier($block->delegate->attributes['delegate']['username']) : $block->delegate->attributes['delegate']['username'],
+    ]);
+
+    expect($result->get())->toHaveCount(1);
+})->with([null, 'strtolower', 'strtoupper']);

--- a/tests/Unit/Services/Search/BlockSearchTest.php
+++ b/tests/Unit/Services/Search/BlockSearchTest.php
@@ -270,14 +270,14 @@ it('should search for blocks by generator with a username', function (?string $m
     expect($result->get())->toHaveCount(1);
 })->with([null, 'strtolower', 'strtoupper']);
 
-it('should search for blocks by generator with a username containing a whitespace', function (?string $modifier) {
+it('should search for blocks by generator with a username containing special characters', function (?string $modifier) {
     Block::factory(10)->create();
 
     $block = Block::factory()->create([
         'generator_public_key' => Wallet::factory()->create([
             'attributes' => [
                 'delegate' => [
-                    'username' => 'something longer than 20 char',
+                    'username' => 'john.doe (old) [new] 2',
                 ],
             ],
         ])->public_key,

--- a/tests/Unit/Services/Search/TransactionSearchTest.php
+++ b/tests/Unit/Services/Search/TransactionSearchTest.php
@@ -284,6 +284,41 @@ it('should search for transactions by wallet with a username', function (?string
     expect($result->get())->toHaveCount(3);
 })->with([null, 'strtolower', 'strtoupper']);
 
+it('should search for transactions by wallet with a username containing a whitespace', function (?string $modifier) {
+    Transaction::factory(10)->create();
+    $username = 'something longer than 20 char';
+
+    $wallet = Wallet::factory()->create([
+        'attributes' => [
+            'delegate' => [
+                'username' => $username,
+            ],
+        ],
+    ]);
+
+    Transaction::factory()->create([
+        'sender_public_key' => $wallet->public_key,
+    ]);
+
+    Transaction::factory()->create([
+        'recipient_id' => $wallet->address,
+    ]);
+
+    Transaction::factory()->create([
+        'asset' => [
+            'payments' => [
+                ['amount' => 10, 'recipientId' => $wallet->address],
+            ],
+        ],
+    ]);
+
+    $result = (new TransactionSearch())->search([
+        'term' => $modifier ? $modifier($username) : $username,
+    ]);
+
+    expect($result->get())->toHaveCount(3);
+})->with([null, 'strtolower', 'strtoupper']);
+
 it('should search for transactions by block with an ID', function (?string $modifier) {
     Transaction::factory(10)->create();
 

--- a/tests/Unit/Services/Search/TransactionSearchTest.php
+++ b/tests/Unit/Services/Search/TransactionSearchTest.php
@@ -284,9 +284,9 @@ it('should search for transactions by wallet with a username', function (?string
     expect($result->get())->toHaveCount(3);
 })->with([null, 'strtolower', 'strtoupper']);
 
-it('should search for transactions by wallet with a username containing a whitespace', function (?string $modifier) {
+it('should search for transactions by wallet with a username containing special characters', function (?string $modifier) {
     Transaction::factory(10)->create();
-    $username = 'something longer than 20 char';
+    $username = 'john.doe (old) [new] 2';
 
     $wallet = Wallet::factory()->create([
         'attributes' => [

--- a/tests/Unit/Services/Search/WalletSearchTest.php
+++ b/tests/Unit/Services/Search/WalletSearchTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\Wallet;
 use App\Services\Search\WalletSearch;
+use Illuminate\Support\Arr;
 
 it('should search for a wallet by address', function (?string $modifier) {
     $wallet = Wallet::factory(10)->create()[0];
@@ -37,12 +38,45 @@ it('should search for a wallet by delegate username in terms', function (?string
     expect($result->get())->toHaveCount(1);
 })->with([null, 'strtolower', 'strtoupper']);
 
+it('can search for a wallet by term matching the username containing a whitespace', function (?string $modifier) {
+    $wallet = Wallet::factory(10)->create()[0];
+    $delegate = $wallet->attributes['delegate'];
+    $delegate['username'] = 'something with a whitespace';
+
+    $wallet->update([
+        'attributes' => array_merge($wallet->attributes, ['delegate' => $delegate]),
+    ]);
+
+    $result = (new WalletSearch())->search([
+        'term' => $modifier ? $modifier('something with a whitespace') : 'something with a whitespace',
+    ]);
+
+    expect($result->get())->toHaveCount(1);
+})->with([null, 'strtolower', 'strtoupper'])->only();
+
 it('should search for a wallet by username', function (?string $modifier) {
     $wallet = Wallet::factory(10)->create()[0];
 
     $result = (new WalletSearch())->search([
         'term'     => '',
         'username' => $modifier ? $modifier($wallet->attributes['delegate']['username']) : $wallet->attributes['delegate']['username'],
+    ]);
+
+    expect($result->get())->toHaveCount(1);
+})->with([null, 'strtolower', 'strtoupper']);
+
+it('can search for a wallet by username containing a whitespace', function (?string $modifier) {
+    $wallet = Wallet::factory(10)->create()[0];
+    $delegate = $wallet->attributes['delegate'];
+    $delegate['username'] = 'something with a whitespace';
+
+    $wallet->update([
+        'attributes' => array_merge($wallet->attributes, ['delegate' => $delegate]),
+    ]);
+
+    $result = (new WalletSearch())->search([
+        'term'     => '',
+        'username' => $modifier ? $modifier('something with a whitespace') : 'something with a whitespace',
     ]);
 
     expect($result->get())->toHaveCount(1);

--- a/tests/Unit/Services/Search/WalletSearchTest.php
+++ b/tests/Unit/Services/Search/WalletSearchTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use App\Models\Wallet;
 use App\Services\Search\WalletSearch;
-use Illuminate\Support\Arr;
 
 it('should search for a wallet by address', function (?string $modifier) {
     $wallet = Wallet::factory(10)->create()[0];
@@ -39,8 +38,8 @@ it('should search for a wallet by delegate username in terms', function (?string
 })->with([null, 'strtolower', 'strtoupper']);
 
 it('can search for a wallet by term matching the username containing a whitespace', function (?string $modifier) {
-    $wallet = Wallet::factory(10)->create()[0];
-    $delegate = $wallet->attributes['delegate'];
+    $wallet               = Wallet::factory(10)->create()[0];
+    $delegate             = $wallet->attributes['delegate'];
     $delegate['username'] = 'something with a whitespace';
 
     $wallet->update([
@@ -66,8 +65,8 @@ it('should search for a wallet by username', function (?string $modifier) {
 })->with([null, 'strtolower', 'strtoupper']);
 
 it('can search for a wallet by username containing a whitespace', function (?string $modifier) {
-    $wallet = Wallet::factory(10)->create()[0];
-    $delegate = $wallet->attributes['delegate'];
+    $wallet               = Wallet::factory(10)->create()[0];
+    $delegate             = $wallet->attributes['delegate'];
     $delegate['username'] = 'something with a whitespace';
 
     $wallet->update([

--- a/tests/Unit/Services/Search/WalletSearchTest.php
+++ b/tests/Unit/Services/Search/WalletSearchTest.php
@@ -37,17 +37,17 @@ it('should search for a wallet by delegate username in terms', function (?string
     expect($result->get())->toHaveCount(1);
 })->with([null, 'strtolower', 'strtoupper']);
 
-it('can search for a wallet by term matching the username containing a whitespace', function (?string $modifier) {
+it('can search for a wallet by term matching the username containing special characters', function (?string $modifier) {
     $wallet               = Wallet::factory(10)->create()[0];
     $delegate             = $wallet->attributes['delegate'];
-    $delegate['username'] = 'something with a whitespace';
+    $delegate['username'] = 'john.doe (old) [new] 2';
 
     $wallet->update([
         'attributes' => array_merge($wallet->attributes, ['delegate' => $delegate]),
     ]);
 
     $result = (new WalletSearch())->search([
-        'term' => $modifier ? $modifier('something with a whitespace') : 'something with a whitespace',
+        'term' => $modifier ? $modifier('john.doe (old) [new] 2') : 'john.doe (old) [new] 2',
     ]);
 
     expect($result->get())->toHaveCount(1);
@@ -64,10 +64,10 @@ it('should search for a wallet by username', function (?string $modifier) {
     expect($result->get())->toHaveCount(1);
 })->with([null, 'strtolower', 'strtoupper']);
 
-it('can search for a wallet by username containing a whitespace', function (?string $modifier) {
+it('can search for a wallet by username containing special characters', function (?string $modifier) {
     $wallet               = Wallet::factory(10)->create()[0];
     $delegate             = $wallet->attributes['delegate'];
-    $delegate['username'] = 'something with a whitespace';
+    $delegate['username'] = 'john.doe (old) [new] 2';
 
     $wallet->update([
         'attributes' => array_merge($wallet->attributes, ['delegate' => $delegate]),
@@ -75,7 +75,7 @@ it('can search for a wallet by username containing a whitespace', function (?str
 
     $result = (new WalletSearch())->search([
         'term'     => '',
-        'username' => $modifier ? $modifier('something with a whitespace') : 'something with a whitespace',
+        'username' => $modifier ? $modifier('john.doe (old) [new] 2') : 'john.doe (old) [new] 2',
     ]);
 
     expect($result->get())->toHaveCount(1);

--- a/tests/Unit/Services/Search/WalletSearchTest.php
+++ b/tests/Unit/Services/Search/WalletSearchTest.php
@@ -52,7 +52,7 @@ it('can search for a wallet by term matching the username containing a whitespac
     ]);
 
     expect($result->get())->toHaveCount(1);
-})->with([null, 'strtolower', 'strtoupper'])->only();
+})->with([null, 'strtolower', 'strtoupper']);
 
 it('should search for a wallet by username', function (?string $modifier) {
     $wallet = Wallet::factory(10)->create()[0];


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the [contributing guidelines](https://ark.dev/docs/program-incentives/guidelines/contributing).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

## Summary

https://app.clickup.com/t/28z0a58

This PR fixes the bug where known wallets containing whitespace would not be found during search. It adds additional tests to all the applications where method to identify wallet "username" is used. These applications refer to search "types" (default search, advanced search with type dropdown set to "Block", "Transaction" and "Wallet").

The issue was that regex determining whether search term could be username was mimicking [regex from the core](https://github.com/ArkEcosystem/core/blob/master/packages/core-api/src/schemas.ts#L117), and it does not allow whitespace. However, as I was told by @faustbrian, Core previously did not impose such restrictions and the "username" **could** contain whitespace.

On top of that, additional restriction was that the username contained less than 20 characters, but I suppose there was no such restriction before in the Core itself, as there are existing wallets with names longer than 20 characters ([Binance Cold Wallet III](https://explorer.ark.io/wallets/Aakg29vVhQhJ5nrsAHysTUqkTBVfmgBSXU) -- 23 characters). As a result of that, even with only whitespace fix, the search wouldn't find wallets with longer name than 20 chars. I've now increased the length restriction to 30. Note: I quickly ran through [Wallets](https://explorer.ark.io/wallets) page and I couldn't find any wallet with a longer username than that. This situation is also covered by unit tests that have been added.

Since we're first discriminating whether given search term is potentially address (length == 34), public key (length == 66 and hexadecimal) and only then checking if it's username, this shouldn't introduce any breaking changes.

<!-- What changes are being made? -->

<!-- Why are these changes necessary? -->

<!-- How were these changes implemented? -->

## Checklist

<!-- Have you done all of these things (where applicable)?  -->

-   [ ] I checked my UI changes against the design and there are no notable differences
-   [ ] I checked my UI changes for any responsiveness issues
-   [ ] I checked my UI changes in light AND dark mode
-   [ ] I checked my (code) changes for obvious issues, debug statements and commented code
-   [ ] I opened a corresponding card on Clickup for any remaining TODOs in my code
-   [ ] I added a short description on how to test this PR _(if necessary)_
-   [ ] Documentation _(if necessary)_
-   [ ] Tests _(if necessary)_
-   [ ] Ready to be merged

<!-- Feel free to add additional comments. -->
